### PR TITLE
Fixes the missing themes value when turning model into {}

### DIFF
--- a/src/drafts/models.py
+++ b/src/drafts/models.py
@@ -12,16 +12,16 @@ class Dataset(models.Model):
     licence = models.CharField(max_length=64, default="")
     licence_other = models.TextField(default="")
 
-    themes = models.TextField(default="")
-    countries = models.TextField(default="")
+    themes = models.TextField(default="[]")
+    countries = models.TextField(default="[]")
     countries_other = models.TextField(default="")
     frequency = models.TextField(default="")
     notifications = models.TextField(default="")
 
     def as_dict(self):
         current = model_to_dict(self)
-        current['themes'] = ast.literal_eval(current['themes'])
-        current['countries'] = ast.literal_eval(current['countries'])
+        current['themes'] = ast.literal_eval(current.get('themes', '[]'))
+        current['countries'] = ast.literal_eval(current.get('countries', '[]'))
         return current
 
 

--- a/src/drafts/util.py
+++ b/src/drafts/util.py
@@ -13,6 +13,8 @@ def convert_to_slug(title):
 
     while True:
         slug = slugify(t)
+        if not slug:
+            raise Exception("Failed to convert {} to a slug".format(t))
 
         draft, dataset = None, None
 


### PR DESCRIPTION
Also raises an error if there is a null title passed to the slug
generation function