### PR TITLE
Cache some of the CKAN calls

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Django==1.10.2
 ckanapi==3.6
+django-memoize==2.0.0

--- a/src/ckan_proxy/logic.py
+++ b/src/ckan_proxy/logic.py
@@ -1,3 +1,4 @@
+from memoize import memoize, delete_memoized
 from ckanapi import NotFound
 
 from .util import ckan_connection_for_admin, ckan_connection_for_user
@@ -8,12 +9,14 @@ def organization_list():
     conn = ckan_connection_for_admin()
     return conn.action.organization_list()
 
+@memoize(timeout=60)
 def organization_list_for_user(user):
     """ Returns a list of organization objects where this user
         has permissions """
     conn = ckan_connection_for_user(user.apikey)
     return conn.action.organization_list_for_user()
 
+@memoize(timeout=60)
 def datasets_for_user(user, search_term="*:*", limit=10, offset=0):
     orgs = organization_list_for_user(user)
     if orgs == []:
@@ -40,3 +43,11 @@ def show_dataset(name):
     except NotFound:
         pass
     return None
+
+def clear_cache():
+    """ Removes all memoization, we don't necessarily want to clear
+        the whole cache, but clearing the dataset cache is a little
+        complex
+    """
+    delete_memoized(organization_list_for_user)
+    delete_memoized(datasets_for_user)

--- a/src/userauth/models.py
+++ b/src/userauth/models.py
@@ -6,6 +6,9 @@ class PublishingUser(AbstractUser):
     apikey = models.CharField(max_length=64)
     USERNAME_FIELD = "email"
 
+    def __repr__(self):
+        return self.email
+
 
 PublishingUser._meta.get_field('email')._unique=True
 PublishingUser.REQUIRED_FIELDS.remove("email")


### PR DESCRIPTION
The CKAN API calls can be on the slow side, and so we will cache them
(memoising) for a short period of time.

Requires a new pip install for new dep/requirement.