### PR TITLE
Implements paging in the Manage Data page.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 Django==1.10.2
 ckanapi==3.6
 django-memoize==2.0.0
+pytz
+python-dateutil==2.6.0

--- a/src/publish_data/templates/manage.html
+++ b/src/publish_data/templates/manage.html
@@ -38,6 +38,17 @@
           {% endfor %}
         </tbody>
       </table>
+
+      <div class="pagination">
+        {% for page in page_range %}
+          {% if page == current_page %}
+            <span>{{ current_page }}</span>
+          {% else %}
+            <span><a href="?page={{ page }}">{{ page }}</a><span>
+          {% endif %}
+        {% endfor %}
+      </div>
+
     </div>
   </main>
 {% endblock %}

--- a/src/publish_data/views.py
+++ b/src/publish_data/views.py
@@ -1,3 +1,5 @@
+import math
+
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import render
 
@@ -16,7 +18,17 @@ def manage_data(request):
     # TODO: Determine default sort order, most recent first with drafts
     # and published interspersed? Paging the remote datasets will be a
     # pain
+    page = 1
+    try:
+        page = int(request.GET.get('page'))
+    except:
+        page = 1
 
-    total, datasets = dataset_list(request.user)
+    total, page_count, datasets = dataset_list(request.user, page)
 
-    return render(request, "manage.html", {"datasets": datasets, "total": total})
+    return render(request, "manage.html", {
+        "datasets": datasets,
+        "total": total,
+        "page_range": range(1, page_count),
+        "current_page": page
+    })


### PR DESCRIPTION
Because we are pulling data from two different sources, but wanting to
sort it by a common field, this gets complicated very quickly.

To fix the problem I've decided that we'll pull the maximum number
needed, merge and sort, and then return a specific subset.  ``

Requires a pip install (requirements change)