### PR TITLE
Provide some date helper functions for working out start/end dates

### DIFF
--- a/src/drafts/tests/test_dates.py
+++ b/src/drafts/tests/test_dates.py
@@ -1,0 +1,85 @@
+from django.test import TestCase
+
+from drafts.util import (calculate_dates_for_year,
+                         calculate_dates_for_month,
+                         calculate_dates_for_quarter)
+
+
+class DatesTestCase(TestCase):
+
+    def test_years(self):
+        (sd, ed) = calculate_dates_for_year(2017)
+
+        assert sd.year == 2017
+        assert sd.month == 1
+        assert sd.day == 1
+
+        assert ed.year == 2017
+        assert ed.month == 12
+        assert ed.day == 31
+
+    def test_month(self):
+        (sd, ed) = calculate_dates_for_month(2, 2009)
+
+        assert sd.year == 2009
+        assert sd.month == 2
+        assert sd.day == 1
+
+        assert ed.year == 2009
+        assert ed.month == 2
+        assert ed.day == 28
+
+    def test_month_leapyear(self):
+        (sd, ed) = calculate_dates_for_month(2, 2012)
+
+        assert sd.year == 2012
+        assert sd.month == 2
+        assert sd.day == 1
+
+        assert ed.year == 2012
+        assert ed.month == 2
+        assert ed.day == 29
+
+    def test_q1(self):
+        (sd, ed) = calculate_dates_for_quarter(1, 2010)
+
+        assert sd.month == 1
+        assert sd.day == 1
+
+        assert ed.month == 3
+        assert ed.day == 31
+
+        assert ed.year == sd.year == 2010
+
+    def test_q2(self):
+        (sd, ed) = calculate_dates_for_quarter(2, 2010)
+
+        assert sd.month == 4
+        assert sd.day == 1
+
+        assert ed.month == 6
+        assert ed.day == 30
+
+        assert ed.year == sd.year == 2010
+
+    def test_q3(self):
+        (sd, ed) = calculate_dates_for_quarter(3, 2010)
+
+        assert sd.month == 7
+        assert sd.day == 1
+
+        assert ed.month == 9
+        assert ed.day == 30
+
+        assert ed.year == sd.year == 2010
+
+    def test_q4(self):
+        (sd, ed) = calculate_dates_for_quarter(4, 2010)
+
+        assert sd.month == 10
+        assert sd.day == 1
+
+        assert ed.month == 12
+        assert ed.day == 31
+
+        assert ed.year == sd.year == 2010

--- a/src/drafts/util.py
+++ b/src/drafts/util.py
@@ -1,7 +1,32 @@
+from calendar import monthrange
+from datetime import datetime
+
 from django.utils.text import slugify
 
 from drafts.models import Dataset
 from ckan_proxy.logic import show_dataset
+
+
+def calculate_dates_for_month(month, year):
+    (_, e,) = monthrange(year, month)
+    return (
+        datetime(year=year, month=month, day=1),
+        datetime(year=year, month=month, day=e)
+    )
+
+def calculate_dates_for_quarter(q, year):
+    first_month_of_quarter = 3 * q - 2
+    last_month_of_quarter = 3 * q
+    sd, _ = calculate_dates_for_month(first_month_of_quarter, year)
+    _, ed = calculate_dates_for_month(last_month_of_quarter, year)
+    return (sd, ed,)
+
+def calculate_dates_for_year(year):
+    return (
+        datetime(year=year, month=1, day=1),
+        datetime(year=year, month=12, day=31)
+    )
+
 
 def convert_to_slug(title):
     """ Checks for a local dataset with this name, and if not


### PR DESCRIPTION
When given a frequency for a dataset, and more detail for a resource
(i.e annually and this is 2017, or quarterly and this is Q3, 2017) these
helper functions will allow us to translate that into a start and end date.