### PR TITLE
Enable filtering of results in 'Manage Data'

### DIFF
--- a/src/publish_data/templates/manage.html
+++ b/src/publish_data/templates/manage.html
@@ -12,39 +12,62 @@
 
     <div class="filtered-table">
       <div class="filter-panel">
-        <label for="name">Filter by name: </label>
-        <input class="form-control" id="name" type="text">
+
+         <form
+              method="GET"
+              action="{% url 'manage_data' %}"
+              class="form">
+
+            <fieldset>
+              <legend class="visuallyhidden">
+                Filter by name
+              </legend>
+
+              <div class="form-group">
+                <label for="name">Filter by name: </label>
+                <input class="form-control" id="q" name="q" type="text" value="{{ q }}">
+                <input class="button" type="submit" value="Filter" >
+                {% if q %}
+                  <a class="font-xsmall" href="{% url 'manage_data' %}">Reset</a>
+                {% endif %}
+              </div>
+            </fieldset>
+          </form>
       </div>
 
-      <table>
-        <thead>
-          <tr>
-            <th>Name</th>
-            <th>Status</th>
-            <th>Actions</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for dataset in datasets %}
+      {% if datasets %}
+        <table>
+          <thead>
             <tr>
-              <td>{{ dataset.title }}</td>
-              <td>{{ dataset.status }}</td>
-              <td>
-                <a href="">Add Data</a> <br/>
-                <a href="{% url 'edit_dataset_full' dataset.name %}">Edit</a> <br/>
-                <a href="">Delete</a>
-              </td>
+              <th>Name</th>
+              <th>Status</th>
+              <th>Actions</th>
             </tr>
-          {% endfor %}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {% for dataset in datasets %}
+              <tr>
+                <td>{{ dataset.title }}</td>
+                <td>{{ dataset.status }}</td>
+                <td>
+                  <a href="">Add Data</a> <br/>
+                  <a href="{% url 'edit_dataset_full' dataset.name %}">Edit</a> <br/>
+                  <a href="">Delete</a>
+                </td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      {% else %}
+        <p>No results found</p>
+      {% endif %}
 
       <div class="pagination">
         {% for page in page_range %}
           {% if page == current_page %}
             <span>{{ current_page }}</span>
           {% else %}
-            <span><a href="?page={{ page }}">{{ page }}</a><span>
+            <span><a href="?page={{ page }}{% if q %}&q={{ q }}{% endif %}">{{ page }}</a><span>
           {% endif %}
         {% endfor %}
       </div>

--- a/src/publish_data/views.py
+++ b/src/publish_data/views.py
@@ -15,20 +15,21 @@ def dashboard(request):
 
 @login_required()
 def manage_data(request):
-    # TODO: Determine default sort order, most recent first with drafts
-    # and published interspersed? Paging the remote datasets will be a
-    # pain
+
+    q = request.GET.get('q')
+
     page = 1
     try:
         page = int(request.GET.get('page'))
     except:
         page = 1
 
-    total, page_count, datasets = dataset_list(request.user, page)
+    total, page_count, datasets = dataset_list(request.user, page, filter_query=q)
 
     return render(request, "manage.html", {
         "datasets": datasets,
         "total": total,
         "page_range": range(1, page_count),
-        "current_page": page
+        "current_page": page,
+        "q": q or ""
     })


### PR DESCRIPTION
Allows the user to filter the datasets that they have access to.  For
drafts this is done by searching inside the title for the filter term,
but for datasets it uses package_search.

Although the default sort order is most recently modified first, I'm not
sure this makes sense once applying a filter as where datasets are
coming from CKAN it is sometimes not obvious why the result is in the
list (it may have matched on description).  It may be best to constrain
the filter to only search CKAN titles rather than any field.