### PR TITLE
Add sample tasks via fixtures and render on dashboard.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ pip install -r requirements.txt
 cd src
 export DJANGO_SETTINGS_MODULE="publish_data.settings.dev"
 ./manage.py migrate
+./manage.py loaddata tasks
 ./manage.py runserver
 ```
 

--- a/src/publish_data/templates/dashboard.html
+++ b/src/publish_data/templates/dashboard.html
@@ -7,4 +7,108 @@
 
 {% block inner_content %}
   <h1 class="heading-large">Dashboard</h1>
+
+
+
+  <section class="dashboard">
+    <div class="table-title">
+      <h2 class="heading-medium">
+        <span class="bignum">{{tasks.update|length}}</span> Update datasets
+      </h2>
+      <div><a href="#" class="font-xsmall">Show all</a></div>
+    </div>
+    <table class="todos">
+      <tbody>
+        {% for task in tasks.update %}
+          <tr>
+            <td>
+              {{ task.description }}
+            </td>
+            <td><span class="overdue">{{ task.label_text }}</span></td>
+            <td class="actions">
+              <a class="update" href="#">Update</a>
+              <a href="#">Skip</a>
+            </td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </section>
+
+
+<section class="dashboard">
+    <div class="table-title">
+      <h2 class="heading-medium">
+        <span class="bignum">{{tasks.fix|length}}</span> Fix datasets
+      </h2>
+      <div><a href="#" class="font-xsmall">Show all</a></div>
+    </div>
+    <table class="todos">
+      <tbody>
+        {% for task in tasks.fix %}
+          <tr>
+            <td>
+              {{ task.description }}
+            </td>
+            <td><span class="overdue">{{ task.label_text }}</span></td>
+            <td class="actions">
+              <a class="update" href="#">Update</a>
+              <a href="#">Skip</a>
+            </td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </section>
+
+  <section class="dashboard">
+    <div class="table-title">
+      <h2 class="heading-medium">
+        <span class="bignum">{{tasks.improve|length}}</span> Improve datasets
+      </h2>
+      <div><a href="#" class="font-xsmall">Show all</a></div>
+    </div>
+    <table class="todos">
+      <tbody>
+        {% for task in tasks.improve %}
+          <tr>
+            <td>
+              {{ task.description }}
+            </td>
+            <td><span class="overdue">{{ task.label_text }}</span></td>
+            <td class="actions">
+              <a class="update" href="#">Update</a>
+              <a href="#">Skip</a>
+            </td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </section>
+
+  <section class="dashboard">
+    <div class="table-title">
+      <h2 class="heading-medium">
+        <span class="bignum">{{tasks.accounts|length}}</span> Manage accounts
+      </h2>
+      <div><a href="#" class="font-xsmall">Show all</a></div>
+    </div>
+    <table class="todos">
+      <tbody>
+        {% for task in tasks.accounts %}
+          <tr>
+            <td>
+              {{ task.description }}
+            </td>
+            <td><span class="overdue">{{ task.label_text }}</span></td>
+            <td class="actions">
+              <a class="update" href="#">Update</a>
+              <a href="#">Skip</a>
+            </td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </section>
+
 {% endblock %}

--- a/src/publish_data/views.py
+++ b/src/publish_data/views.py
@@ -4,14 +4,18 @@ from django.contrib.auth.decorators import login_required
 from django.shortcuts import render
 
 from publish_data.logic import dataset_list
+from tasks.logic import get_tasks_for_user, user_ignore_task
 
 def home(request):
     if request.user.is_authenticated():
         return dashboard(request)
     return render(request, "home.html", {})
 
+@login_required()
 def dashboard(request):
-    return render(request, "dashboard.html", {})
+    tasks = get_tasks_for_user(request.user)
+
+    return render(request, "dashboard.html", {"tasks": tasks})
 
 @login_required()
 def manage_data(request):

--- a/src/tasks/fixtures/tasks.json
+++ b/src/tasks/fixtures/tasks.json
@@ -1,0 +1,102 @@
+[
+  {
+    "model": "tasks.task",
+    "pk": 1,
+    "fields": {
+      "owning_organisation": "cabinet-office",
+      "required_permission_name" : "",
+      "description": "Update 'Anti-social behaviour order statistics, England and Wales' by 3 February 2017",
+      "category": "update"
+    }
+  },
+  {
+    "model": "tasks.task",
+    "pk": 2,
+    "fields": {
+      "owning_organisation": "cabinet-office",
+      "required_permission_name" : "",
+      "description": "Add missing data to 'Statistics of mentally disordered offenders, England'",
+      "category": "improve"
+    }
+  },
+  {
+    "model": "tasks.task",
+    "pk": 3,
+    "fields": {
+      "owning_organisation": "cabinet-office",
+      "required_permission_name" : "",
+      "description": "Delete Maria Izquierdo’s account",
+      "category": "accounts"
+    }
+  },
+  {
+    "model": "tasks.task",
+    "pk": 4,
+    "fields": {
+      "owning_organisation": "cabinet-office",
+      "required_permission_name" : "",
+      "description": "Give ‘editor’ permissions to Max Froumentin",
+      "category": "accounts"
+    }
+  },
+  {
+    "model": "tasks.task",
+    "pk": 5,
+    "fields": {
+      "owning_organisation": "cabinet-office",
+      "required_permission_name" : "",
+      "description": "Replace broken link in 'Prison population projections'",
+      "category": "fix"
+    }
+  },
+  {
+    "model": "tasks.task",
+    "pk": 6,
+    "fields": {
+      "owning_organisation": "department-for-environment-food-and-rural-affairs",
+      "required_permission_name" : "",
+      "description": "Update 'Anti-social behaviour order statistics, England and Wales' by 3 February 2017",
+      "category": "update"
+    }
+  },
+  {
+    "model": "tasks.task",
+    "pk": 7,
+    "fields": {
+      "owning_organisation": "department-for-environment-food-and-rural-affairs",
+      "required_permission_name" : "",
+      "description": "Add missing data to 'Statistics of mentally disordered offenders, England'",
+      "category": "improve"
+    }
+  },
+  {
+    "model": "tasks.task",
+    "pk": 8,
+    "fields": {
+      "owning_organisation": "department-for-environment-food-and-rural-affairs",
+      "required_permission_name" : "",
+      "description": "Delete Maria Izquierdo’s account",
+      "category": "accounts"
+    }
+  },
+  {
+    "model": "tasks.task",
+    "pk": 9,
+    "fields": {
+      "owning_organisation": "department-for-environment-food-and-rural-affairs",
+      "required_permission_name" : "",
+      "description": "Give ‘editor’ permissions to Max Froumentin",
+      "category": "accounts"
+    }
+  },
+  {
+    "model": "tasks.task",
+    "pk": 10,
+    "fields": {
+      "owning_organisation": "department-for-environment-food-and-rural-affairs",
+      "required_permission_name" : "",
+      "description": "Replace broken link in 'Prison population projections'",
+      "category": "fix"
+    }
+  }
+]

--- a/tools/dev_run.sh
+++ b/tools/dev_run.sh
@@ -1,4 +1,5 @@
 source /usr/lib/publishing/bin/activate
 cd /vagrant/src
 export DJANGO_SETTINGS_MODULE="publish_data.settings.dev"
+./manage.py loaddata tasks
 ./manage.py runserver 0.0.0.0:8000


### PR DESCRIPTION
Adds some sample tasks via a fixture in the tasks app, which has a
handful of tasks for CO and DEFRA.  Also renders these tasks on the
dashboard.html page (but no styling yet and HTML stolen from prototype).

To import the data, you need to run

```
./manage.py loaddata tasks
```
