### PR TITLE
Enable skipping of tasks that the user is not interested in

### DIFF
--- a/src/publish_data/templates/dashboard.html
+++ b/src/publish_data/templates/dashboard.html
@@ -27,7 +27,7 @@
             <td><span class="overdue">{{ task.label_text }}</span></td>
             <td class="actions">
               <a class="update" href="#">Update</a>
-              <a href="#">Skip</a>
+              <a href="{% url 'skip_task' task.id %}">Skip</a>
             </td>
           </tr>
         {% endfor %}
@@ -53,7 +53,7 @@
             <td><span class="overdue">{{ task.label_text }}</span></td>
             <td class="actions">
               <a class="update" href="#">Update</a>
-              <a href="#">Skip</a>
+              <a href="{% url 'skip_task' task.id %}">Skip</a>
             </td>
           </tr>
         {% endfor %}
@@ -78,7 +78,7 @@
             <td><span class="overdue">{{ task.label_text }}</span></td>
             <td class="actions">
               <a class="update" href="#">Update</a>
-              <a href="#">Skip</a>
+              <a href="{% url 'skip_task' task.id %}">Skip</a>
             </td>
           </tr>
         {% endfor %}
@@ -103,7 +103,7 @@
             <td><span class="overdue">{{ task.label_text }}</span></td>
             <td class="actions">
               <a class="update" href="#">Update</a>
-              <a href="#">Skip</a>
+              <a href="{% url 'skip_task' task.id %}">Skip</a>
             </td>
           </tr>
         {% endfor %}

--- a/src/publish_data/urls.py
+++ b/src/publish_data/urls.py
@@ -10,4 +10,5 @@ urlpatterns = [
     url(r'manage$', views.manage_data, name='manage_data'),
     url(r'^accounts/', include('userauth.urls')),
     url(r'^dataset/',  include('drafts.urls')),
+    url(r'^task/',  include('tasks.urls')),
 ]

--- a/src/tasks/logic.py
+++ b/src/tasks/logic.py
@@ -24,4 +24,9 @@ def get_tasks_for_user(user):
     return tasks
 
 def user_ignore_task(user, task):
+    """
+    Set the user to ignore the task. We *could* check whether they've
+    actually got permission to view the task, but if they chose to ignore
+    a task they can't actually see then it doesn't make much difference.
+    """
     UserHiddenTask.objects.create(user=user, task=task)

--- a/src/tasks/tests.py
+++ b/src/tasks/tests.py
@@ -1,5 +1,6 @@
 from django.test import TestCase
 from django.contrib.auth import get_user_model
+from django.urls import reverse
 
 from ckan_proxy.logic import organization_list_for_user
 from ckan_proxy.util import test_user_key
@@ -12,8 +13,12 @@ class TasksTestCase(TestCase):
     def setUp(self):
         self.test_user = get_user_model().objects.create(
             username="Test User",
+            email="test-signin@localhost",
             apikey=test_user_key()
         )
+        self.test_user.set_password("password")
+        self.test_user.save()
+
         self.org_names = [o['name']
             for o in organization_list_for_user(self.test_user)]
 
@@ -29,6 +34,13 @@ class TasksTestCase(TestCase):
             description = "Task description",
             category = "fix"
         )
+        self.simple_task_improve = Task.objects.create(
+            owning_organisation = self.org_names[0],
+            required_permission_name = "",
+            description = "Task description",
+            category = "improve"
+        )
+
 
     def test_ok(self):
         tasks = get_tasks_for_user(self.test_user)
@@ -42,3 +54,17 @@ class TasksTestCase(TestCase):
 
         tasks = get_tasks_for_user(self.test_user)
         assert len(tasks['fix']) == 0, tasks['fix']
+
+    def test_hide_web(self):
+        response = self.client.post(reverse('signin'), {
+            "email": "test-signin@localhost",
+            "password": "password"
+        })
+        assert response.status_code == 302
+
+        tasks = get_tasks_for_user(self.test_user)
+        assert len(tasks['improve']) == 1
+
+        resp = self.client.get(reverse('skip_task', args=[tasks['improve'][0].id]))
+        assert resp.status_code == 302
+        assert resp.url == "/", resp.url

--- a/src/tasks/urls.py
+++ b/src/tasks/urls.py
@@ -1,0 +1,7 @@
+from django.conf.urls import url
+
+import tasks.views as v
+
+urlpatterns = [
+    url(r'skip/(?P<task_id>\d+)$', v.skip_task, name='skip_task'),
+]

--- a/src/tasks/views.py
+++ b/src/tasks/views.py
@@ -1,3 +1,15 @@
-from django.shortcuts import render
+from django.http import HttpResponseRedirect
+from django.shortcuts import render, get_object_or_404
+from django.contrib.auth.decorators import login_required
+from django.urls import reverse
 
-# Create your views here.
+from tasks.models import Task
+from tasks.logic import user_ignore_task
+
+
+@login_required()
+def skip_task(request, task_id):
+    task = get_object_or_404(Task, pk=task_id)
+    user_ignore_task(request.user, task)
+
+    return HttpResponseRedirect(request.META.get('HTTP_REFERER', '/'))


### PR DESCRIPTION
Provides a URL /task/skip/ID so that the current user can skip a task
that they are not interested in without the task being deleted (so that
other members of the organisation can still see it).

Changes the url in dashboard.html so that clicking the skip link takes
the user to the skip view, and then redirects them back to the
dashboard.