### PR TITLE
Move slug handling to the form so we can handle errors on bad slugs

### DIFF
--- a/src/drafts/forms.py
+++ b/src/drafts/forms.py
@@ -3,6 +3,7 @@ from django import forms
 
 import drafts.choices as choices
 from drafts.models import Dataset
+from drafts.util import convert_to_slug
 
 class DatasetForm(forms.Form):
     title = forms.CharField(label=_('Title'), max_length=100, required=True)
@@ -12,6 +13,14 @@ class DatasetForm(forms.Form):
         widget=forms.Textarea,
         required=True
     )
+
+    def clean(self):
+        name = convert_to_slug(self.cleaned_data['title'])
+        if not name:
+            self._errors["password"] = [_("Title is not valid")]
+        self.cleaned_data["name"] = name
+        return self.cleaned_data
+
 
 
 class CountryForm(forms.Form):

--- a/src/drafts/tests/test_create.py
+++ b/src/drafts/tests/test_create.py
@@ -40,6 +40,15 @@ class DraftsTestCase(TestCase):
     def _get_dataset(self):
         return Dataset.objects.get(name=self.dataset_name)
 
+    def test_bad_slug(self):
+        response = self.client.post(reverse('new_dataset', args=[]),
+            {
+                'title': '[]',
+                'description': 'A test description'
+            })
+        assert response.status_code == 200
+
+
     def test_country(self):
         u = reverse('edit_country', args=[self.dataset_name])
         response = self.client.get(u)

--- a/src/drafts/util.py
+++ b/src/drafts/util.py
@@ -39,7 +39,7 @@ def convert_to_slug(title):
     while True:
         slug = slugify(t)
         if not slug:
-            raise Exception("Failed to convert {} to a slug".format(t))
+            return None
 
         draft, dataset = None, None
 

--- a/src/drafts/views.py
+++ b/src/drafts/views.py
@@ -5,7 +5,6 @@ from django.urls import reverse
 
 import drafts.forms as f
 from drafts.models import Dataset, Datafile
-from drafts.util import convert_to_slug
 
 from django.views.generic.edit import FormView, UpdateView
 
@@ -29,12 +28,10 @@ class DatasetCreate(FormView):
     template_name = 'drafts/edit_title.html'
 
     def form_valid(self, form):
-        name = convert_to_slug(form.cleaned_data['title'])
-
         dataset = Dataset.objects.create(
                 title=form.cleaned_data['title'],
                 description=form.cleaned_data['description'],
-                name=name
+                name=form.cleaned_data['name']
         )
         self.object = dataset
         return super(DatasetCreate, self).form_valid(form)


### PR DESCRIPTION
If we get something that can't be slugified we can now complain that the
form isn't valid and show an error.  We are asserting that it is a bad
title so when we get around to error messages defined in forms we need
to make sure we log it as a bad title.

Fixes #69