### PR TITLE
Change draft views to use a form wizard

### DIFF
--- a/src/drafts/forms.py
+++ b/src/drafts/forms.py
@@ -2,7 +2,7 @@ from django.utils.translation import ugettext as _
 from django import forms
 
 import drafts.choices as choices
-from drafts.models import Dataset
+from drafts.models import Dataset, Datafile
 from drafts.util import convert_to_slug
 
 class DatasetForm(forms.Form):
@@ -19,27 +19,14 @@ class DatasetForm(forms.Form):
             name = convert_to_slug(self.cleaned_data['title'])
             if not name:
                 self._errors['title'] = [_('This title is not valid')]
-
             self.cleaned_data['name'] = name
         return self.cleaned_data
 
+class LicenceForm(forms.ModelForm):
 
-
-class CountryForm(forms.Form):
-    countries = forms.MultipleChoiceField(
-        required=False,
-        widget=forms.CheckboxSelectMultiple,
-        choices=choices.COUNTRY_CHOICES,
-    )
-
-
-class LicenceForm(forms.Form):
-    licence = forms.ChoiceField(widget=forms.RadioSelect, choices=choices.LICENCE_CHOICES, required=True)
-    licence_other = forms.CharField(
-        label=_('Other'),
-        max_length=1024,
-        required=False
-    )
+    class Meta:
+        model = Dataset
+        fields = ['licence', 'licence_other']
 
     def clean(self):
         if 'licence' in self.cleaned_data:
@@ -48,19 +35,73 @@ class LicenceForm(forms.Form):
         return self.cleaned_data
 
 
-class FrequencyForm(forms.Form):
-    frequency = forms.ChoiceField(widget=forms.RadioSelect, choices=choices.FREQUENCY_CHOICES)
+
+class CountryForm(forms.ModelForm):
+
+    countries = forms.MultipleChoiceField(
+        required=False,
+        widget=forms.CheckboxSelectMultiple,
+        choices=choices.COUNTRY_CHOICES,
+    )
+
+    class Meta:
+        model = Dataset
+        fields = ['countries']
 
 
-class AddFileForm(forms.Form):
-    title = forms.CharField(label=_('Title'), max_length=100, required=True)
-    url = forms.URLField(label=_('URL'), max_length=100, required=True)
+class FrequencyForm(forms.ModelForm):
+
+    frequency = forms.CharField(required=True)
+
+    class Meta:
+        model = Dataset
+        fields = ['frequency']
 
 
-class NotificationsForm(forms.Form):
-    notifications = forms.ChoiceField(
-        widget=forms.RadioSelect,
-        choices=(('yes', 'Yes'),('no', 'No')))
+class FrequencyWeeklyForm(forms.ModelForm):
+    class Meta:
+        model = Dataset
+        fields = []
+
+
+class FrequencyMonthlyForm(forms.ModelForm):
+    class Meta:
+        model = Dataset
+        fields = []
+
+
+class FrequencyQuarterlyForm(forms.ModelForm):
+    class Meta:
+        model = Dataset
+        fields = []
+
+class FrequencyAnnuallyForm(forms.ModelForm):
+    class Meta:
+        model = Dataset
+        fields = []
+
+
+class AddFileForm(forms.ModelForm):
+    class Meta:
+        model = Datafile
+        fields = ['title', 'url']
+
+class StubForm(forms.ModelForm):
+    """ This is a do-nothing form for handling a page
+        that has no form """
+    class Meta:
+        model = Dataset
+        fields = []
+
+
+class NotificationsForm(forms.ModelForm):
+
+    notifications = forms.CharField(required=True)
+
+    class Meta:
+        model = Dataset
+        fields = ['notifications']
+
 
 class DateForm(forms.Form):
     start_date = forms.CharField(required=False)

--- a/src/drafts/models.py
+++ b/src/drafts/models.py
@@ -23,10 +23,13 @@ class Dataset(models.Model):
 
     def as_dict(self):
         current = model_to_dict(self)
-        current['themes'] = ast.literal_eval(current.get('themes', '[]'))
-        current['countries'] = ast.literal_eval(current.get('countries', '[]'))
+        if not isinstance(current.get('countries'), list):
+            current['countries'] = ast.literal_eval(current.get('countries', '[]'))
         return current
 
+    def countries_as_list(self):
+        current = model_to_dict(self)
+        return ast.literal_eval(current.get('countries', '[]'))
 
 class Datafile(models.Model):
     title = models.CharField(max_length=128)

--- a/src/drafts/templates/drafts/check_dataset.html
+++ b/src/drafts/templates/drafts/check_dataset.html
@@ -40,9 +40,17 @@
       </tr>
       <tr>
         <td>
-          Files
+          Links
         </td>
         <td>
+          <ul>
+          {% for link in dataset.files.all %}
+            <li>
+              {{ link.title }}<br/>
+              {{ link.url }}
+            </li>
+          {% endfor %}
+          </ul>
         </td>
         <td class="change-answer">
           <a href="files?change=1">
@@ -56,7 +64,7 @@
         </td>
         <td>
           <ul>
-            {% for country in dataset.countries %}
+            {% for country in dataset.countries_as_list %}
               <li>
                 {{ country|title }}
               </li>
@@ -98,7 +106,8 @@
     </tbody>
   </table>
 
-  <form action="{% url 'check_dataset' dataset.name %}" method="POST">
+  <form action="{% url 'edit_dataset_step' dataset.name 'check_dataset' %}" method="POST">
+    {{ wizard.management_form }}
     {% csrf_token %}
     <div class="form-group">
       <input type="submit" class="button" value="Accept">

--- a/src/drafts/templates/drafts/edit_addfile.html
+++ b/src/drafts/templates/drafts/edit_addfile.html
@@ -11,7 +11,8 @@
     Add a link
   </h1>
 
-  <form action="{% url 'edit_addfile' dataset.name %}" method="POST">
+  <form action="{% url 'edit_dataset_step' dataset.name 'add_file' %}" method="POST">
+    {{ wizard.management_form }}
     {% csrf_token %}
 
     <ul class="errorlist"><li>This field is required.</li></ul>
@@ -34,7 +35,7 @@
         <input
             class="form-control form-control-2-3"
             id="id_url"
-            name="url"
+            name="{{ wizard.form.url.html_name }}"
             type="url"
             required=""
             value=""/>
@@ -51,7 +52,7 @@
         <input
             class="form-control form-control-2-3"
             id="id_title"
-            name="title"
+            name="{{ wizard.form.title.html_name }}"
             type="text"
             required=""
             value=""/>

--- a/src/drafts/templates/drafts/edit_country.html
+++ b/src/drafts/templates/drafts/edit_country.html
@@ -16,7 +16,8 @@
     of the following.
   </p>
 
-  <form action="{% url 'edit_country' dataset.name %}" method="POST">
+  <form action="{% url 'edit_dataset_step' dataset.name 'country' %}" method="POST">
+    {{ wizard.management_form }}
     {% csrf_token %}
     <ul class="errorlist"><li>This field is required.</li></ul>
 
@@ -26,46 +27,46 @@
         <label class="block-label form-checkbox" for="id_countries_0">
           <input
               id="id_countries_0"
-              name="countries"
+              name="{{ wizard.form.countries.html_name }}"
               type="checkbox"
               value="england"
-              {% if 'england' in dataset.countries %}checked{% endif %} />
+              {% if 'england' in wizard.form.countries.value %}checked{% endif %} />
           <span>England</span>
         </label>
         <label class="block-label form-checkbox" for="id_countries_1">
           <input
               id="id_countries_1"
-              name="countries"
+              name="{{ wizard.form.countries.html_name }}"
               type="checkbox"
               value="wales"
-              {% if 'wales' in dataset.countries %}checked{% endif %} />
+              {% if 'wales' in wizard.form.countries.value %}checked{% endif %} />
           <span>Wales</span>
         </label>
         <label class="block-label form-checkbox" for="id_countries_2">
           <input
               id="id_countries_2"
-              name="countries"
+              name="{{ wizard.form.countries.html_name }}"
               type="checkbox"
               value="scotland"
-              {% if 'scotland' in dataset.countries %}checked{% endif %} />
+              {% if 'scotland' in wizard.form.countries.value %}checked{% endif %} />
           <span>Scotland</span>
         </label>
         <label class="block-label form-checkbox" for="id_countries_3">
           <input
               id="id_countries_3"
-              name="countries"
+              name="{{ wizard.form.countries.html_name }}"
               type="checkbox"
               value="northern-ireland"
-              {% if 'northern-ireland' in dataset.countries %}checked{% endif %}  />
+              {% if 'northern-ireland' in wizard.form.countries.value %}checked{% endif %}  />
           <span>Northern Ireland</span>
         </label>
         <label class="block-label form-checkbox" for="id_countries_4">
           <input
               id="id_countries_4"
-              name="countries"
+              name="{{ wizard.form.countries.html_name }}"
               type="checkbox"
               value="overseas"
-              {% if 'overseas' in dataset.countries %}checked{% endif %}  />
+              {% if 'overseas' in wizard.form.countries.value %}checked{% endif %}  />
           <span>Overseas</span>
         </label>
       </fieldset>

--- a/src/drafts/templates/drafts/edit_frequency.html
+++ b/src/drafts/templates/drafts/edit_frequency.html
@@ -11,7 +11,8 @@
     How often is this dataset updated?
   </h1>
 
-  <form action="{% url 'edit_frequency' dataset.name %}" method="POST">
+  <form action="{% url 'edit_dataset_step' dataset.name 'frequency' %}" method="POST">
+    {{ wizard.management_form }}
     {% csrf_token %}
 
     <ul class="errorlist"><li>This field is required.</li></ul>
@@ -22,64 +23,64 @@
         <label class="block-label selection-button-radio" for="id_frequency_0">
           <input
               id="id_frequency_0"
-              name="frequency"
+              name="{{ wizard.form.frequency.html_name }}"
               type="radio"
               value="daily"
-              {% if dataset.frequency == 'daily' %}checked{% endif %}/>
+              {% if wizard.form.frequency.value == 'daily' %}checked{% endif %}/>
           <span>Every day</span>
         </label>
         <label class="block-label selection-button-radio" for="id_frequency_1">
           <input
               id="id_frequency_1"
-              name="frequency"
+              name="{{ wizard.form.frequency.html_name }}"
               type="radio"
               value="weekly"
-              {% if dataset.frequency == 'weekly' %}checked{% endif %}/>
+              {% if wizard.form.frequency.value == 'weekly' %}checked{% endif %}/>
           <span>Every week</span>
         </label>
         <label class="block-label selection-button-radio" for="id_frequency_2">
           <input
               id="id_frequency_2"
-              name="frequency"
+              name="{{ wizard.form.frequency.html_name }}"
               type="radio"
               value="monthly"
-              {% if dataset.frequency == 'monthly' %}checked{% endif %}/>
+              {% if wizard.form.frequency.value == 'monthly' %}checked{% endif %}/>
           <span>Every month</span>
         </label>
         <label class="block-label selection-button-radio" for="id_frequency_3">
           <input
               id="id_frequency_3"
-              name="frequency"
+              name="{{ wizard.form.frequency.html_name }}"
               type="radio"
               value="quarterly"
-              {% if dataset.frequency == 'quarterly' %}checked{% endif %} />
+              {% if wizard.form.frequency.value == 'quarterly' %}checked{% endif %} />
           <span>Every quarter</span>
         </label>
         <label class="block-label selection-button-radio" for="id_frequency_4">
           <input
               id="id_frequency_4"
-              name="frequency"
+              name="{{ wizard.form.frequency.html_name }}"
               type="radio"
               value="annually"
-              {% if dataset.frequency == 'annually' %}checked{% endif %} />
+              {% if wizard.form.frequency.value == 'annually' %}checked{% endif %} />
           <span>Every year (January to December)</span>
         </label>
         <label class="block-label selection-button-radio" for="id_frequency_5">
           <input
               id="id_frequency_5"
-              name="frequency"
+              name="{{ wizard.form.frequency.html_name }}"
               type="radio"
               value="financial-year"
-              {% if dataset.frequency == 'financial-year' %}checked{% endif %} />
+              {% if wizard.form.frequency.value == 'financial-year' %}checked{% endif %} />
           <span>Every year (April to March)</span>
         </label>
         <label class="block-label selection-button-radio" for="id_frequency_6">
           <input
               id="id_frequency_6"
-              name="frequency"
+              name="{{ wizard.form.frequency.html_name }}"
               type="radio"
               value="never"
-              {% if dataset.frequency == 'never' %}checked{% endif %} />
+              {% if wizard.form.frequency.value == 'never' %}checked{% endif %} />
           Never
         </label>
       </fieldset>

--- a/src/drafts/templates/drafts/edit_frequency_month.html
+++ b/src/drafts/templates/drafts/edit_frequency_month.html
@@ -13,8 +13,9 @@
 
   <form
       method="post"
-      action="{% url 'edit_frequency_monthly' dataset.name %}"
+      action="{% url 'edit_dataset_step' dataset.name 'frequency_monthly' %}"
       class="form">
+    {{ wizard.management_form }}
     {% csrf_token %}
 
     <fieldset>

--- a/src/drafts/templates/drafts/edit_frequency_quarter.html
+++ b/src/drafts/templates/drafts/edit_frequency_quarter.html
@@ -13,8 +13,9 @@
 
   <form
       method="post"
-      action="{% url 'edit_frequency_quarterly' dataset.name %}"
+      action="{% url 'edit_dataset_step' dataset.name 'frequency_quarterly' %}"
       class="form">
+    {{ wizard.management_form }}
     {% csrf_token %}
 
     <fieldset>

--- a/src/drafts/templates/drafts/edit_frequency_week.html
+++ b/src/drafts/templates/drafts/edit_frequency_week.html
@@ -13,8 +13,9 @@
 
   <form
       method="post"
-      action="{% url 'edit_frequency_weekly' dataset.name %}"
+      action="{% url 'edit_dataset_step' dataset.name 'frequency_weekly' %}"
       class="form">
+    {{ wizard.management_form }}
     {% csrf_token %}
 
     <fieldset>

--- a/src/drafts/templates/drafts/edit_frequency_year.html
+++ b/src/drafts/templates/drafts/edit_frequency_year.html
@@ -13,8 +13,9 @@
 
   <form
       method="post"
-      action="{% url 'edit_frequency_annually' dataset.name %}"
+      action="{% url 'edit_dataset_step' dataset.name 'frequency_annually' %}"
       class="form">
+    {{ wizard.management_form }}
     {% csrf_token %}
 
     <fieldset>

--- a/src/drafts/templates/drafts/edit_licence.html
+++ b/src/drafts/templates/drafts/edit_licence.html
@@ -7,7 +7,9 @@
 
 {% block inner_content %}
 
-  {% if form.errors %}
+
+
+  {% if wizard.form.errors %}
     <div
         class="error-summary"
         role="group"
@@ -20,14 +22,14 @@
       </h1>
 
       <ul class="error-summary-list">
-        {% for error in form.non_field_errors %}
+        {% for error in wizard.form.non_field_errors %}
           <li>
             {{ error }}
             <span class="visuallyhidden">.</span>
           </li>
         {% endfor %}
 
-          {% for error in form.licence.errors %}
+          {% for error in wizard.form.licence.errors %}
           <li>
             <a href="#licence_form_group">
               Please select a licence for your dataset
@@ -36,7 +38,7 @@
           </li>
           {% endfor %}
 
-          {% for error in form.licence_other.errors %}
+          {% for error in wizard.form.licence_other.errors %}
           <li>
             <a href="#licence_other_label">
               Please type the name of your licence
@@ -59,60 +61,62 @@
     which means the data within them can be copied and used by anyone.
   </p>
 
-  <form action="{% url 'edit_licence' dataset.name %}" method="POST">
+  <form action="{% url 'edit_dataset_step' dataset.name 'licence' %}" method="POST">
+
+    {{ wizard.management_form }}
     {% csrf_token %}
     <div
         class="form-group {% if form.licence.errors %}error{% endif %}"
         id="licence_form_group">
       <fieldset>
         <legend class="visually-hidden">Choose a licence</legend>
-        {% for error in form.licence.errors %}
+        {% for error in wizard.form.licence.errors %}
           <span class="error-message">{{ error }}</span>
         {% endfor %}
 
         <label class="block-label selection-button-radio" for="id_licence_0">
           <input
               id="id_licence_0"
-              name="licence"
+              name="{{ wizard.form.licence.html_name }}"
               type="radio"
               value="ogl"
-              {% if form.licence.value == 'ogl' %}checked{% endif %} />
+              {% if wizard.form.licence.value == 'ogl' %}checked{% endif %} />
           <span>Open Government Licence</span>
         </label>
         <label class="block-label selection-button-radio" for="id_licence_1">
           <input
               id="id_licence_1"
-              name="licence"
+              name="{{ wizard.form.licence.html_name }}"
               type="radio"
               value="inspire"
-              {% if form.licence.value == 'inspire' %}checked{% endif %} />
+              {% if wizard.form.licence.value == 'inspire' %}checked{% endif %} />
           <span>INSPIRE</span>
         </label>
         <label class="block-label selection-button-radio" for="id_licence_2">
           <input
               id="id_licence_2"
-              name="licence"
+              name="{{ wizard.form.licence.html_name }}"
               type="radio"
               value="other"
-              {% if form.licence.value == 'other' %}checked{% endif %}  />
+              {% if wizard.form.licence.value == 'other' %}checked{% endif %}  />
           <span>Other:</span>
         </label>
       </fieldset>
     </div>
-    <div class="form-group {% if form.licence_other.errors %}error{% endif %}">
+    <div class="form-group {% if wizard.form.licence_other.errors %}error{% endif %}">
       <label class="form-label" for="id_licence_other" id="licence_other_label">
         Name of your licence:
       </label>
-      {% for error in form.licence_other.errors %}
+      {% for error in wizard.form.licence_other.errors %}
         <span class="error-message">{{ error }}</span>
       {% endfor %}
       <input
           class="form-control"
           id="id_licence_other"
-          name="licence_other"
+          name="{{ wizard.form.licence_other.html_name }}"
           type="text"
           {% if form.licence_other.value %}
-            value="{{ form.licence_other.value }}"
+            value="{{ wizard.form.licence_other.value }}"
           {% endif %}
           />
     </div>

--- a/src/drafts/templates/drafts/edit_notifications.html
+++ b/src/drafts/templates/drafts/edit_notifications.html
@@ -11,7 +11,8 @@ Get notifications
     Get notifications
   </h1>
 
-  <form action="{% url 'edit_notifications' dataset.name %}" method="POST">
+  <form action="{% url 'edit_dataset_step' dataset.name 'notifications' %}" method="POST">
+    {{ wizard.management_form }}
     {% csrf_token %}
 
     <ul class="errorlist"><li>This field is required.</li></ul>
@@ -30,7 +31,7 @@ Get notifications
             for="id_notifications_0">
           <input
               id="id_notifications_0"
-              name="notifications"
+              name="{{ wizard.form.notifications.html_name }}"
               type="radio"
               value="yes"
               required="">
@@ -42,7 +43,7 @@ Get notifications
             for="id_notifications_1">
           <input
               id="id_notifications_1"
-              name="notifications"
+              name="{{ wizard.form.notifications.html_name }}"
               type="radio"
               value="no"
               required="">

--- a/src/drafts/templates/drafts/edit_title.html
+++ b/src/drafts/templates/drafts/edit_title.html
@@ -76,7 +76,7 @@
         <input
             class="form-control form-control-2-3"
             id="id_title"
-            name="title"
+            name="{{ form.title.html_name }}"
             type="text"
             value="{{ form.title.value|default:"" }}"/>
       </div>
@@ -104,7 +104,7 @@
             rows="10"
             class="form-control form-control-2-3"
             id="id_description"
-            name="description">{{ form.description.value|default:""}}</textarea>
+            name="{{ form.description.html_name }}">{{ form.description.value|default:""}}</textarea>
       </div>
     </fieldset>
 

--- a/src/drafts/templates/drafts/show_files.html
+++ b/src/drafts/templates/drafts/show_files.html
@@ -21,6 +21,7 @@
         </tr>
       </thead>
       <tbody>
+      {{dataset}}
         {% for file in dataset.files.all %}
           <tr>
             <td>{{ file.title }} </td>
@@ -39,16 +40,17 @@
 
     <form
         method="POST"
-        action="{% url 'edit_notifications' dataset.name %}"
+        action="{% url 'edit_dataset_step' dataset.name 'notifications' %}"
         class="form">
       <div class="form-group">
+        {{ wizard.management_form }}
         {% csrf_token %}
         <input type="submit" class="button" value="Continue">
       </div>
     </form>
 
     <div class="form-group">
-      <a href="{% url 'edit_addfile' dataset.name %}">Add another file</a>
+      <a href="{% url 'edit_dataset_step' dataset.name 'add_file' %}">Add another file</a>
     </div>
 
   </main>

--- a/src/drafts/tests/test_create.py
+++ b/src/drafts/tests/test_create.py
@@ -5,6 +5,12 @@ from drafts.models import Dataset
 
 from ckan_proxy.util import test_user_key
 
+def get_wizard_data(data, name):
+    tmp = data
+    tmp.update({"dataset_wizard-current_step": name})
+    return tmp
+
+
 class DraftsTestCase(TestCase):
 
     def setUp(self):
@@ -50,123 +56,124 @@ class DraftsTestCase(TestCase):
 
 
     def test_country(self):
-        u = reverse('edit_country', args=[self.dataset_name])
+        u = reverse('edit_dataset_step', args=[self.dataset_name, 'country'])
         response = self.client.get(u)
         assert response.status_code == 200
 
         # No selected countries
-        response = self.client.post(u, {})
+        response = self.client.post(u, get_wizard_data({}, 'country'))
         assert response.status_code == 302
         assert self._get_dataset().countries == '[]'
 
-        response = self.client.post(u, {'countries': 'england'})
+        response = self.client.post(u, get_wizard_data({'country-countries': 'england'}, 'country'))
         assert response.status_code == 302
         assert self._get_dataset().countries == "['england']", \
             self._get_dataset().countries
 
     def test_licence(self):
-        u = reverse('edit_licence', args=[self.dataset_name])
+        u = reverse('edit_dataset_step', args=[self.dataset_name, 'licence'])
         response = self.client.get(u)
         assert response.status_code == 200
 
         # No selected countries, expect a fail
-        response = self.client.post(u, {})
+        response = self.client.post(u, get_wizard_data({}, "licence"))
         assert response.status_code == 200
 
-        response = self.client.post(u, {'licence': 'ogl'})
+        response = self.client.post(u, get_wizard_data({'licence-licence': 'ogl'}, 'licence'))
         assert response.status_code == 302
         assert self._get_dataset().licence == "ogl", \
             self._get_dataset().licence
 
-        response = self.client.post(u, {'licence': 'other',
-            'licence_other': 'pretend licence'})
+        response = self.client.post(u, get_wizard_data({'licence-licence': 'other',
+            'licence-licence_other': 'pretend licence'}, 'licence'))
         assert response.status_code == 302
         obj = self._get_dataset()
         assert obj.licence == "other", obj.licence
         assert obj.licence_other == "pretend licence"
 
     def test_frequency(self):
-        u = reverse('edit_frequency', args=[self.dataset_name])
+        u = reverse('edit_dataset_step', args=[self.dataset_name, 'frequency'])
         response = self.client.get(u)
         assert response.status_code == 200
 
-        response = self.client.post(u, {})
+        response = self.client.post(u, get_wizard_data({}, 'frequency'))
         assert response.status_code == 200
 
-        response = self.client.post(u, {'frequency': 'never'})
+        response = self.client.post(u, get_wizard_data({'frequency-frequency': 'never'}, 'frequency'))
         assert response.status_code == 302
         assert self._get_dataset().frequency == "never", \
             self._get_dataset().frequency
 
+    """
     def test_frequency_details(self):
-        u = reverse('edit_frequency', args=[self.dataset_name])
-        response = self.client.post(u, {'frequency': 'weekly'})
+        u = reverse('edit_dataset_step', args=[self.dataset_name, 'frequency'])
+        response = self.client.post(u, get_wizard_data({'frequency-frequency': 'weekly'}, 'frequency'))
         assert response.status_code == 302
         assert response.url == reverse('edit_frequency_weekly',
-            args=[self.dataset_name])
+            args=[self.dataset_name, 'frequency_weekly'])
 
-        response = self.client.post(u, {'frequency': 'monthly'})
+        response = self.client.post(u, get_wizard_data({'frequency-frequency': 'monthly'}, 'frequency'))
         assert response.status_code == 302
-        assert response.url == reverse('edit_frequency_monthly',
-            args=[self.dataset_name])
+        assert response.url == reverse('edit_dataset_step',
+            args=[self.dataset_name, 'frequency_monthly'])
 
-        response = self.client.post(u, {'frequency': 'quarterly'})
+        response = self.client.post(u, get_wizard_data({'frequency-frequency': 'quarterly'}, 'frequency'))
         assert response.status_code == 302
-        assert response.url == reverse('edit_frequency_quarterly',
-            args=[self.dataset_name])
+        assert response.url == reverse('edit_dataset_step',
+            args=[self.dataset_name, 'frequency_quarterly'])
 
-        response = self.client.post(u, {'frequency': 'annually'})
+        response = self.client.post(u, get_wizard_data({'frequency-frequency': 'annually'}, 'frequency'))
         assert response.status_code == 302
-        assert response.url == reverse('edit_frequency_annually',
-            args=[self.dataset_name])
+        assert response.url == reverse('edit_dataset_step',
+            args=[self.dataset_name, 'frequency_annually'])
 
-        response = self.client.post(u, {'frequency': 'financial-year'})
+        response = self.client.post(u, get_wizard_data({'frequency-frequency': 'financial-year'}, 'frequency'))
         assert response.status_code == 302
-        assert response.url == reverse('edit_frequency_financial-year',
-            args=[self.dataset_name])
-
+        assert response.url == reverse('edit_dataset_step-year',
+            args=[self.dataset_name, 'frequency_financial_year'])
+    """
 
     def test_notifications(self):
-        u = reverse('edit_notifications', args=[self.dataset_name])
+        u = reverse('edit_dataset_step', args=[self.dataset_name,'notifications'])
         response = self.client.get(u)
         assert response.status_code == 200
 
-        response = self.client.post(u, {})
+        response = self.client.post(u, get_wizard_data({}, 'notifications'))
         assert response.status_code == 200
 
-        response = self.client.post(u, {'notifications': 'yes'})
+        response = self.client.post(u, get_wizard_data({'notifications-notifications': 'yes'}, 'notifications'))
         assert response.status_code == 302
         assert self._get_dataset().notifications == "yes", \
             self._get_dataset().notifications
 
     def test_check(self):
-        u = reverse('check_dataset', args=[self.dataset_name])
+        u = reverse('edit_dataset_step', args=[self.dataset_name, 'check_dataset'])
         response = self.client.get(u)
         assert response.status_code == 200
 
     def test_addfile(self):
-        u = reverse('edit_addfile', args=[self.dataset_name])
+        u = reverse('edit_dataset_step', args=[self.dataset_name, 'add_file'])
         response = self.client.get(u)
         assert response.status_code == 200
 
         # Must add a file
-        response = self.client.post(u, {})
+        response = self.client.post(u, get_wizard_data({}, 'add_file'))
         assert response.status_code == 200
 
-        response = self.client.post(u, {'url': 'http://data.gov.uk'})
+        response = self.client.post(u, get_wizard_data({'add_file-url': 'http://data.gov.uk'}, 'add_file'))
         assert response.status_code == 200
 
-        response = self.client.post(u, {'title': 'Not really a file'})
+        response = self.client.post(u, get_wizard_data({'add_file-title': 'Not really a file'}, 'add_file'))
         assert response.status_code == 200
 
-        response = self.client.post(u, {
-            'url': 'http://data.gov.uk',
-            'title': 'Not really a file'
-        })
+        response = self.client.post(u, get_wizard_data({
+            'add_file-url': 'http://data.gov.uk',
+            'add_file-title': 'Not really a file'
+        }, 'add_file'))
         assert response.status_code == 302
 
     def test_showfiles(self):
-        u = reverse('show_files', args=[self.dataset_name])
+        u = reverse('edit_dataset_step', args=[self.dataset_name, 'files'])
         response = self.client.get(u)
         assert response.status_code == 200
 

--- a/src/drafts/urls.py
+++ b/src/drafts/urls.py
@@ -3,52 +3,30 @@ from django.contrib.auth.decorators import login_required
 
 import drafts.views as v
 
+
+dataset_wizard = login_required(
+    v.DatasetWizard.as_view(
+        v.FORMS,
+        url_name='edit_dataset_step',
+        done_step_name='done',
+        condition_dict={
+            'frequency_weekly': v.show_weekly_frequency,
+            'frequency_monthly': v.show_monthly_frequency,
+            'frequency_quarterly': v.show_quarterly_frequency,
+            'frequency_annually': v.show_annually_frequency,
+        })
+)
+
 urlpatterns = [
-    url(r'new$', login_required(v.DatasetCreate.as_view()), name='new_dataset'),
-    url(r'edit/(?P<dataset_name>[\w-]+)$',
-        login_required(v.DatasetFullEditView.as_view()),
+    url(r'^new/$',
+        login_required(v.DatasetCreate.as_view()),
+        name='new_dataset'),
+
+    url(r'edit/^(?P<dataset_name>[\w-]+)$',
+        login_required(v.DatasetEdit.as_view()),
         name='edit_dataset_full'),
 
-    url(r'(?P<dataset_name>[\w-]+)/edit$',
-        login_required(v.DatasetEditView.as_view()),
-        name='edit_dataset'),
-    url(r'(?P<dataset_name>[\w-]+)/country$',
-        login_required(v.EditCountryView.as_view()),
-        name='edit_country'),
-    url(r'(?P<dataset_name>[\w-]+)/licence$',
-        login_required(v.EditLicenceView.as_view()),
-        name='edit_licence'),
-    url(r'(?P<dataset_name>[\w-]+)/frequency$',
-        login_required(v.EditFrequencyView.as_view()),
-        name='edit_frequency'),
-    url(r'(?P<dataset_name>[\w-]+)/add$',
-        login_required(v.AddFileView.as_view()),
-        name='edit_addfile'),
-    url(r'(?P<dataset_name>[\w-]+)/files$',
-        login_required(v.show_files),
-        name='show_files'),
-    url(r'(?P<dataset_name>[\w-]+)/notifications$',
-        login_required(v.EditNotificationView.as_view()),
-        name='edit_notifications'),
-    url(r'(?P<dataset_name>[\w-]+)/check$',
-        login_required(v.check_dataset),
-        name='check_dataset'),
-
-    # Frequency details
-    url(r'(?P<dataset_name>[\w-]+)/frequency/weekly$',
-        login_required(v.FrequencyWeeklyView.as_view()),
-        name='edit_frequency_weekly'),
-    url(r'(?P<dataset_name>[\w-]+)/frequency/monthly$',
-        login_required(v.FrequencyMonthlyView.as_view()),
-        name='edit_frequency_monthly'),
-    url(r'(?P<dataset_name>[\w-]+)/frequency/quarterly$',
-        login_required(v.FrequencyQuarterlyView.as_view()),
-        name='edit_frequency_quarterly'),
-    url(r'(?P<dataset_name>[\w-]+)/frequency/annually$',
-        login_required(v.FrequencyAnnuallyView.as_view()),
-        name='edit_frequency_annually'),
-    url(r'(?P<dataset_name>[\w-]+)/frequency/financial-year$',
-        login_required(v.FrequencyFinancialYearView.as_view()),
-        name='edit_frequency_financial-year'),
+    url(r'^(?P<dataset_name>[\w-]+)/(?P<step>.+)$',
+        dataset_wizard,
+        name='edit_dataset_step'),
 ]
-

--- a/src/publish_data/templates/manage.html
+++ b/src/publish_data/templates/manage.html
@@ -51,7 +51,7 @@
                 <td>{{ dataset.status }}</td>
                 <td>
                   <a href="">Add Data</a> <br/>
-                  <a href="{% url 'edit_dataset_full' dataset.name %}">Edit</a> <br/>
+                  <a href="">Edit</a> <br/>
                   <a href="">Delete</a>
                 </td>
               </tr>


### PR DESCRIPTION
Changes the draft dataset creation views (and therefore forms) to use a
form wizard, rather than a collection of Class-based views. Most forms are now ModelForms so that they can take care of saving themselves.

Requires that templates have a new block like csrf_token like

```{{ wizard.management_form   }}```

All uses of the form tag in the template should be prefixed with wizard,
so ```form.errrors``` becomes ```wizard.form.errors```

When setting the name on inputs, rather than setting it manually we now
need to use ```wizard.form.FIELD.html_name```

I've updated all of the templates, but as some haven't been finished yet they may still be incorrect.

Tests still pass, but we should move to a better solution for testing
the wizard that doesn't involve mangling input data.