### PR TITLE
Change licence ID to match CKAN

### DIFF
--- a/src/drafts/templates/drafts/edit_licence.html
+++ b/src/drafts/templates/drafts/edit_licence.html
@@ -78,7 +78,7 @@
               id="id_licence_0"
               name="{{ wizard.form.licence.html_name }}"
               type="radio"
-              value="ogl"
+              value="uk-ogl"
               {% if wizard.form.licence.value == 'ogl' %}
                 checked
               {% endif %} />


### PR DESCRIPTION
This'll save a translation from a local identifier to a CKAN compatible one.