### PR TITLE
Change the travis badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/datagovuk/publish_data_alpha.svg)](https://travis-ci.org/datagovuk/publish_data_alpha)
+[![Build Status](https://travis-ci.org/datagovuk/publish_data_alpha.svg?branch=master)](https://travis-ci.org/datagovuk/publish_data_alpha)
 
 
 # Publish Data


### PR DESCRIPTION
Change the travis badge to just show master so I don't panic when a branch is failing.