### PR TITLE
Resolves an error when publishing and form isn't valid.

### DIFF
--- a/src/ckan_proxy/convert.py
+++ b/src/ckan_proxy/convert.py
@@ -27,6 +27,14 @@ def draft_to_ckan(draft):
             {
                 "key": "notifications",
                 "value": draft.notifications
+            },
+            {
+                "key": "summary",
+                "value": draft.summary
+            },
+            {
+                "key": "licence_other",
+                "value": draft.licence_other
             }
         ]
     }

--- a/src/ckan_proxy/logic.py
+++ b/src/ckan_proxy/logic.py
@@ -64,12 +64,18 @@ def dataset_show(name, user=None):
 def dataset_create(data, user):
     conn = ckan_connection_for_user(user.apikey)
     res = conn.action.package_create(**data)
+
+    clear_cache()
+
     return res
 
 
 def dataset_update(data, user):
     conn = ckan_connection_for_user(user.apikey)
     res = conn.action.package_update(**data)
+
+    clear_cache()
+
     return res
 
 


### PR DESCRIPTION

Fixes an error where if the user randomly go to the check_dataset page and
try to publish (like after an edit) user was redirected back to
organisation page.  This is because we store the data in the draft
object, rather than relying on the form data in the session so forms 
are expected to be invalid at this point.

Also, now deletes draft after successful publish.