### PR TITLE
Do not show draft datasets on the manage data page.

### DIFF
--- a/src/publish_data/logic.py
+++ b/src/publish_data/logic.py
@@ -18,20 +18,6 @@ def dataset_list(user, page=1, filter_query=None):
     per_page = 20
     max_fetch = per_page * page
 
-    # TODO: This should be organisation specific
-
-    # Find relevant datasets from the drafts database
-    count = Dataset.objects.count()
-
-    drafts = Dataset.objects
-    if filter_query:
-        drafts = drafts.filter(title__icontains=filter_query)
-    drafts = drafts.all().order_by("-last_edit_date")[0:max_fetch]
-
-    for d in drafts:
-        d.last_edit_date = d.last_edit_date.replace(tzinfo=utc)
-        d.status = _("draft")
-
     # Find relevant datasets from CKAN
     results = datasets_for_user(
         user,
@@ -52,10 +38,8 @@ def dataset_list(user, page=1, filter_query=None):
             return obj['metadata_modified']
         return obj.last_edit_date
 
-    resultset = sorted(list(drafts) + datasets, key=get_key, reverse=True)
-
-    total = results['count'] + count
+    total = results['count']
     page_count = math.ceil(float(total) / per_page)
 
     offset = (page * per_page) - per_page
-    return (total, page_count, resultset[offset:offset+per_page],)
+    return (total, page_count, datasets,)

--- a/src/publish_data/templates/manage.html
+++ b/src/publish_data/templates/manage.html
@@ -48,7 +48,6 @@
         <thead>
           <tr>
             <th>Name</th>
-            <th>Status</th>
             <th class="actions">Actions</th>
           </tr>
         </thead>
@@ -56,10 +55,9 @@
           {% for dataset in datasets %}
             <tr>
               <td><a href="{{ ckan_host }}/dataset/{{ dataset.name }}">{{ dataset.title }}</a></td>
-              <td>{{ dataset.status }}</td>
               <td class="actions">
                 {% if dataset.name %}
-                  <a href="{% url 'edit_dataset_files' dataset.name %}?change=1">Add Data</a><br/>
+                  <a href="{% url 'edit_dataset_files' dataset.name %}?change=1">Add&nbsp;Data</a><br/>
                   <a href="{% url 'edit_dataset_check_dataset' dataset.name %}">Edit</a><br/>
                 {% endif %}
               </td>


### PR DESCRIPTION
We now longer need to do mixed pagination (of local data and API call)
so we can remove the drafts when we lookup the list of datasets for the
user.