### PR TITLE
Auto select org when user only a member of one

### DIFF
--- a/src/datasets/templates/datasets/check_dataset.html
+++ b/src/datasets/templates/datasets/check_dataset.html
@@ -59,9 +59,11 @@
           {{ organisation.title }}
         </td>
         <td class="change-answer">
+          {% if not single_organisation %}
           <a href="organisation?change=1">
             Change <span class="visuallyhidden">description</span>
           </a>
+          {% endif %}
         </td>
       </tr>
       <tr>

--- a/src/datasets/templates/datasets/check_dataset.html
+++ b/src/datasets/templates/datasets/check_dataset.html
@@ -51,21 +51,21 @@
           </a>
         </td>
       </tr>
-      <tr>
-        <td>
-          Organisation
-        </td>
-        <td>
-          {{ organisation.title }}
-        </td>
-        <td class="change-answer">
-          {% if not single_organisation %}
-          <a href="organisation?change=1">
-            Change <span class="visuallyhidden">description</span>
-          </a>
-          {% endif %}
-        </td>
-      </tr>
+      {% if not single_organisation %}
+        <tr>
+          <td>
+            Organisation
+          </td>
+          <td>
+            {{ organisation.title }}
+          </td>
+          <td class="change-answer">
+            <a href="organisation?change=1">
+              Change <span class="visuallyhidden">description</span>
+            </a>
+          </td>
+        </tr>
+      {% endif %}
       <tr>
         <td>
           Links

--- a/src/datasets/tests/test_create.py
+++ b/src/datasets/tests/test_create.py
@@ -132,20 +132,22 @@ class DatasetsTestCase(TestCase):
             'edit_dataset_organisation',
             args=[self.dataset_name]
         )
+        # With only a single organisation, we expect a redirect
         response = self.client.get(u)
-        assert response.status_code == 200
+        assert response.status_code == 302
 
+        # User in a single organisation so will be redirected
         response = self.client.post(u, {})
-        assert response.status_code == 200
+        assert response.status_code == 302
 
         response = self.client.post(
             u,
             {
-                'organisation': 'cabinet-office'
+                'organisation': 'test-organisation'
             }
         )
         assert response.status_code == 302
-        assert self._get_dataset().organisation == "cabinet-office", \
+        assert self._get_dataset().organisation == "test-organisation", \
             self._get_dataset().organisation
 
 

--- a/src/datasets/views.py
+++ b/src/datasets/views.py
@@ -66,6 +66,12 @@ def edit_dataset_details(request, dataset_name):
 def edit_organisation(request, dataset_name):
     dataset = get_object_or_404(Dataset, name=dataset_name)
 
+    organisations = get_orgs_for_user(request)
+    if len(organisations) == 1:
+        dataset.organisation, _ = organisations[0]
+        dataset.save()
+        return _redirect_to(request, 'edit_dataset_licence',[dataset.name])
+
     form = f.OrganisationForm(request.POST or None, instance=dataset)
     if request.method == 'POST':
         if form.is_valid():
@@ -75,7 +81,7 @@ def edit_organisation(request, dataset_name):
     return render(request, "datasets/edit_organisation.html", {
         'form': form,
         'dataset': dataset.as_dict(),
-        'organisations': get_orgs_for_user(request),
+        'organisations': organisations,
         'editing': request.GET.get('change', '') == '1',
     })
 
@@ -284,6 +290,9 @@ def check_dataset(request, dataset_name):
         dataset = ckan_to_draft(dataset_name)
 
     organisation = organization_show(dataset.organisation)
+    organisations = get_orgs_for_user(request)
+    single_organisation = len(organisations) == 1
+
 
     if request.method == 'POST':
         f = dataset_update \
@@ -305,7 +314,8 @@ def check_dataset(request, dataset_name):
     return render(request, "datasets/check_dataset.html", {
         'dataset': dataset,
         'licence': dataset.licence if dataset.licence != 'other' else dataset.licence_other,
-        'organisation': organisation
+        'organisation': organisation,
+        'single_organisation': single_organisation
     })
 
 


### PR DESCRIPTION
When a user is only in one organisation, there is no need to ask them
which organisation they are publishing for.  This PR will auto-select
the single org if they are only in one.

As a result, on the check_dataset page we don't show the organisation.

Fixes #133