### PR TITLE
Edit full dataset endpoint.

### DIFF
--- a/src/datasets/forms.py
+++ b/src/datasets/forms.py
@@ -25,6 +25,7 @@ class DatasetForm(forms.Form):
             self.cleaned_data['name'] = name
         return self.cleaned_data
 
+
 class EditDatasetForm(forms.ModelForm):
     title = forms.CharField(label=_('Title'), max_length=100, required=True)
     summary = forms.CharField(label=_('Summary'), max_length=200, required=True)
@@ -38,6 +39,36 @@ class EditDatasetForm(forms.ModelForm):
     class Meta:
         model = Dataset
         fields = ['title', 'summary', 'description']
+
+
+
+class FullDatasetForm(forms.ModelForm):
+    title = forms.CharField(label=_('Title'), max_length=100, required=True)
+    summary = forms.CharField(label=_('Summary'), max_length=200, required=True)
+    description = forms.CharField(
+        label=_('Additional Information'),
+        max_length=1024,
+        widget=forms.Textarea,
+        required=True
+    )
+
+    class Meta:
+        model = Dataset
+        fields = [
+            'title', 'summary', 'description',
+            'licence', 'licence_other', 'organisation',
+            'frequency', 'notifications', 'name'
+        ]
+
+
+    def clean(self):
+        if 'licence' in self.cleaned_data:
+            if self.cleaned_data['licence'] == 'other' \
+                    and not self.cleaned_data['licence_other']:
+                self._errors['licence_other'] = \
+                    [_('Please type the name of your licence')]
+
+        return self.cleaned_data
 
 
 

--- a/src/datasets/templates/datasets/edit_dataset.html
+++ b/src/datasets/templates/datasets/edit_dataset.html
@@ -1,0 +1,26 @@
+{% extends 'main_with_navbar.html' %}
+{% load static %}
+
+{% block page_title %}
+  Edit dataset
+{% endblock %}
+
+{% block inner_content %}
+
+  {% include 'datasets/includes/error_box.html' %}
+
+  <h1 class="heading-large">
+    Edit '{{ dataset.title }}'
+  </h1>
+
+  <form action="{% url 'edit_full_dataset' dataset.name %}" method="POST">
+    {% csrf_token %}
+
+    {{ form.as_p }}
+
+
+    <div class="form-group">
+      <input type="submit" class="button" value="Save"/>
+    </div>
+  </form>
+{% endblock %}

--- a/src/datasets/tests/__init__.py
+++ b/src/datasets/tests/__init__.py
@@ -42,7 +42,18 @@ class MockCKANRequestHandler(BaseHTTPRequestHandler):
         response = self.load_file(name)
 
         if name == 'package_show' \
-                and params.get('id') == 'a-test-dataset-for-create':
+                and (params.get('id') == 'a-test-dataset-for-create' or
+                    params.get('id') == 'a-test-dataset-for-edit'):
+            err = {"success": False,
+            "error": {
+                "message": "Not found",
+                "__type": "Not Found Error"
+            }}
+            response = json.dumps(err)
+
+        if name == 'package_show' \
+                and (params.get('id').startswith('new') or
+                    params.get('id').startswith('edit')):
             err = {"success": False,
             "error": {
                 "message": "Not found",

--- a/src/datasets/tests/test_edit.py
+++ b/src/datasets/tests/test_edit.py
@@ -1,0 +1,73 @@
+from django.test import TestCase
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from datasets.models import Dataset
+
+from ckan_proxy.util import test_user_key
+
+
+class DatasetEditTestCase(TestCase):
+
+    def setUp(self):
+        self.test_user = get_user_model().objects.create(
+            email="test-signin@localhost",
+            username="Test User Signin",
+            apikey=test_user_key()
+        )
+        self.test_user.set_password("password")
+        self.test_user.save()
+
+        # Log the user in
+        self.client.post(reverse('signin'), {
+            "email": "test-signin@localhost",
+            "password": "password"
+        })
+
+        # Both test the initial dataset creation, and get a name we can
+        # use for the remaining tests.
+        self.dataset_name = self._create_new_dataset()
+
+
+    def _create_new_dataset(self):
+        response = self.client.post(reverse('new_dataset', args=[]), {
+                'title': 'A test dataset for edit',
+                'description': 'A test description',
+                'summary': 'A test summary',
+        })
+        assert response.status_code == 302
+        parts = response.url.split('/')
+
+        return parts[2]
+
+    def _edit_dataset(self, name=None):
+        response = self.client.get(
+            reverse('edit_full_dataset',
+            args=[name or self.dataset_name]))
+        return response
+
+
+    def test_bad_doesnotexist(self):
+        r = self._edit_dataset('nope')
+        assert r.status_code == 404
+
+    def test_edit_get(self):
+        r = self._edit_dataset(self.dataset_name)
+        assert r.status_code == 200
+        assert b'A test dataset for edit' in r.content
+
+
+    def test_edit_update(self):
+        response = self.client.post(
+            reverse('edit_full_dataset',
+            args=[self.dataset_name]),
+            {
+                'name': self.dataset_name,
+                'title': 'A test dataset for edit',
+                'description': 'A test description',
+                'summary': 'Updated summary',
+                'licence': 'uk-ogl',
+                'notifications': 'no'
+            })
+
+        ds = Dataset.objects.get(name=self.dataset_name)
+

--- a/src/datasets/tests/test_misc.py
+++ b/src/datasets/tests/test_misc.py
@@ -1,10 +1,17 @@
 from django.test import TestCase
 
-from datasets.util import url_exists
+from datasets.util import url_exists, convert_to_slug
 
 
 class MiscTestCase(TestCase):
 
+    def test_ignored_slug_name_new(self):
+        s = convert_to_slug('new')
+        assert s == 'new1'
+
+    def test_ignored_slug_name_edit(self):
+        s = convert_to_slug('edit')
+        assert s == 'edit1'
 
     def test_url_exists_ok(self):
         exists, fmt = url_exists('https://data.gov.uk')

--- a/src/datasets/urls.py
+++ b/src/datasets/urls.py
@@ -9,6 +9,10 @@ urlpatterns = [
         login_required(v.new_dataset),
         name='new_dataset'),
 
+    url(r'^edit/(?P<dataset_name>[\w-]+)$',
+        login_required(v.edit_full_dataset),
+        name='edit_full_dataset'),
+
     url(r'^(?P<dataset_name>[\w-]+)/organisation$',
         login_required(v.edit_organisation),
         name='edit_dataset_organisation'),

--- a/src/datasets/util.py
+++ b/src/datasets/util.py
@@ -73,6 +73,12 @@ def convert_to_slug(title):
         if not slug:
             return None
 
+
+        if slug in ['edit', 'new']:
+            t = "{}{}".format(title, counter)
+            counter += 1
+            continue
+
         draft, dataset = None, None
 
         try:

--- a/src/datasets/views.py
+++ b/src/datasets/views.py
@@ -34,9 +34,27 @@ def new_dataset(request):
                 reverse('edit_dataset_organisation', args=[obj.name])
             )
 
+
     return render(request, "datasets/edit_title.html", {
         "form": form,
         "dataset": {},
+    })
+
+
+def edit_full_dataset(request, dataset_name):
+    dataset = get_object_or_404(Dataset, name=dataset_name)
+
+    form = f.FullDatasetForm(request.POST or None, instance=dataset)
+    if request.method == 'POST':
+        if form.is_valid():
+            obj = form.save()
+            return HttpResponseRedirect(
+                reverse('manage_data') + "?edited=1"
+            )
+
+    return render(request, "datasets/edit_dataset.html", {
+        "form": form,
+        "dataset": dataset,
     })
 
 


### PR DESCRIPTION
Adds a new url for editing the entire dataset (at once) and uses a new
form that includes all of the relevant fields EXCEPT files.
Files/links/whatever will have to be handled as a sub-form and we still
need to decide whether we are checking URLs on save, or just new URLs,
or neither.