### PR TITLE
Change the view link on manage data.

### DIFF
--- a/src/publish_data/templates/manage.html
+++ b/src/publish_data/templates/manage.html
@@ -60,7 +60,13 @@
         <tbody>
           {% for dataset in datasets %}
             <tr>
-              <td><a href="{{ ckan_host }}/dataset/{{ dataset.name }}">{{ dataset.title }}</a></td>
+              <td>
+                {% if ckan_host %}
+                  <a href="{{ ckan_host }}/dataset/{{ dataset.name }}">{{ dataset.title }}</a>
+                {% else %}
+                  {{ dataset.title }}
+                {% endif %}
+              </td>
               <td>{% if dataset.published %}published{% else %}draft{% endif %}</td>
               <td class="actions">
                 {% if dataset.name %}

--- a/src/publish_data/views.py
+++ b/src/publish_data/views.py
@@ -4,6 +4,7 @@ from django.shortcuts import render
 from datasets.logic import dataset_list
 from tasks.logic import get_tasks_for_user
 from stats.logic import get_stats
+from runtime_config.logic import get_config
 
 def home(request):
     if request.user.is_authenticated():
@@ -39,11 +40,14 @@ def manage_data(request):
         request.user, page, filter_query=q
     )
 
+    ckan_host = get_config('ckan.host') or ''
+
     return render(request, "manage.html", {
         "datasets": datasets,
         "total": total,
         "page_range": range(1, page_count),
         "current_page": page,
         "q": q or "",
-        "result": result or ""
+        "result": result or "",
+        "ckan_host": ckan_host,
     })


### PR DESCRIPTION
When the ckan.host property is configured in runtime_config, this will
change the link to point to the dataset page on that instance.  If no
ckan.host setting is available, then it will just show the text instead
of a link.