### PR TITLE
Allows flow state to be stored in the session.

### DIFF
--- a/src/datasets/templates/datasets/check_dataset.html
+++ b/src/datasets/templates/datasets/check_dataset.html
@@ -1,11 +1,14 @@
 {% extends 'main_with_navbar.html' %}
 {% load static %}
+{% load flow_state %}
 
 {% block page_title %}
   Check your dataset
 {% endblock %}
 
 {% block inner_content %}
+  {{ request|clear_flow_state }}
+
   <h1 class="heading-large">
     Check your dataset
   </h1>

--- a/src/datasets/templates/datasets/edit_adddoc.html
+++ b/src/datasets/templates/datasets/edit_adddoc.html
@@ -1,5 +1,6 @@
 {% extends 'main_with_navbar.html' %}
 {% load static %}
+{% load flow_state %}
 
 {% block page_title %}
   Add documentation

--- a/src/datasets/templates/datasets/edit_addfile.html
+++ b/src/datasets/templates/datasets/edit_addfile.html
@@ -1,5 +1,6 @@
 {% extends 'main_with_navbar.html' %}
 {% load static %}
+{% load flow_state %}
 
 {% block page_title %}
   Add a link

--- a/src/datasets/templates/datasets/edit_addfile_month.html
+++ b/src/datasets/templates/datasets/edit_addfile_month.html
@@ -1,5 +1,6 @@
 {% extends 'main_with_navbar.html' %}
 {% load static %}
+{% load flow_state %}
 
 {% block page_title %}
   Time period

--- a/src/datasets/templates/datasets/edit_addfile_quarter.html
+++ b/src/datasets/templates/datasets/edit_addfile_quarter.html
@@ -1,5 +1,6 @@
 {% extends 'main_with_navbar.html' %}
 {% load static %}
+{% load flow_state %}
 
 {% block page_title %}
   Time period

--- a/src/datasets/templates/datasets/edit_addfile_week.html
+++ b/src/datasets/templates/datasets/edit_addfile_week.html
@@ -1,5 +1,6 @@
 {% extends 'main_with_navbar.html' %}
 {% load static %}
+{% load flow_state %}
 
 {% block page_title %}
   Time period

--- a/src/datasets/templates/datasets/edit_addfile_year.html
+++ b/src/datasets/templates/datasets/edit_addfile_year.html
@@ -1,5 +1,6 @@
 {% extends 'main_with_navbar.html' %}
 {% load static %}
+{% load flow_state %}
 
 {% block page_title %}
   Time period

--- a/src/datasets/templates/datasets/edit_dataset.html
+++ b/src/datasets/templates/datasets/edit_dataset.html
@@ -1,5 +1,6 @@
 {% extends 'main_with_navbar.html' %}
 {% load static %}
+{% load flow_state %}
 
 {% block page_title %}
   Edit dataset

--- a/src/datasets/templates/datasets/edit_frequency.html
+++ b/src/datasets/templates/datasets/edit_frequency.html
@@ -1,5 +1,6 @@
 {% extends 'main_with_navbar.html' %}
 {% load static %}
+{% load flow_state %}
 
 {% block page_title %}
   How often is this dataset updated?

--- a/src/datasets/templates/datasets/edit_licence.html
+++ b/src/datasets/templates/datasets/edit_licence.html
@@ -1,5 +1,7 @@
 {% extends 'main_with_navbar.html' %}
 {% load static %}
+{% load flow_state %}
+{% load flow_state %}
 
 {% block page_title %}
   Add dataset licence

--- a/src/datasets/templates/datasets/edit_location.html
+++ b/src/datasets/templates/datasets/edit_location.html
@@ -1,5 +1,6 @@
 {% extends 'main_with_navbar.html' %}
 {% load static %}
+{% load flow_state %}
 
 {% block page_title %}
   Add dataset area

--- a/src/datasets/templates/datasets/edit_notifications.html
+++ b/src/datasets/templates/datasets/edit_notifications.html
@@ -1,5 +1,6 @@
 {% extends 'main_with_navbar.html' %}
 {% load static %}
+{% load flow_state %}
 
 {% block page_title %}
   Get notifications

--- a/src/datasets/templates/datasets/edit_organisation.html
+++ b/src/datasets/templates/datasets/edit_organisation.html
@@ -1,5 +1,6 @@
 {% extends 'main_with_navbar.html' %}
 {% load static %}
+{% load flow_state %}
 
 {% block page_title %}
   Choose an organisation

--- a/src/datasets/templates/datasets/edit_title.html
+++ b/src/datasets/templates/datasets/edit_title.html
@@ -1,9 +1,11 @@
 {% extends 'main_with_navbar.html' %}
 {% load static %}
+{% load flow_state %}
 
 {% block page_title %}
   Add dataset title
 {% endblock %}
+{% load flow_state %}
 
 {% block inner_content %}
 

--- a/src/datasets/templates/datasets/show_docs.html
+++ b/src/datasets/templates/datasets/show_docs.html
@@ -1,5 +1,6 @@
 {% extends 'main_with_navbar.html' %}
 {% load static %}
+{% load flow_state %}
 
 {% block page_title %}
   Dataset documentation

--- a/src/datasets/templates/datasets/show_files.html
+++ b/src/datasets/templates/datasets/show_files.html
@@ -1,5 +1,6 @@
 {% extends 'main_with_navbar.html' %}
 {% load static %}
+{% load flow_state %}
 
 {% block page_title %}
   Dataset links

--- a/src/datasets/views.py
+++ b/src/datasets/views.py
@@ -59,6 +59,8 @@ def edit_full_dataset(request, dataset_name):
     if not user_can_edit_dataset(request.user, dataset):
         return HttpResponseForbidden()
 
+    request.session['flow-state'] = 'editing'
+
     form = f.FullDatasetForm(request.POST or None, instance=dataset)
     if request.method == 'POST':
         if form.is_valid():
@@ -541,7 +543,7 @@ def check_dataset(request, dataset_name):
         return HttpResponseForbidden()
 
     # Reset the flow state
-    request.session['flow-state'] = None
+    request.session['flow-state'] = 'checking'
 
     organisation = dataset.organisation
     organisations = organisations_for_user(request.user)
@@ -554,6 +556,8 @@ def check_dataset(request, dataset_name):
 
         err = publish_to_ckan(dataset)
         index_dataset(dataset)
+
+        request.session['flow-state'] = None
 
         return HttpResponseRedirect(
             reverse('manage_data') + '?result=created'

--- a/src/datasets/views.py
+++ b/src/datasets/views.py
@@ -15,7 +15,21 @@ from datasets.models import Dataset, Datafile
 from datasets.search import index_dataset
 from datasets.search import delete_dataset as unindex_dataset
 
+def _set_flow_state(request):
+    ''' If the query string contains a 'state' string then
+    we will set the current state, otherwise we will leave
+    it unchanged '''
+    return_to = request.GET.get('state')
+    if return_to == 'edit':
+        request.session['flow-state'] = 'editing'
+    elif return_to == 'check':
+        request.session['flow-state'] = 'checking'
+
+
 def new_dataset(request):
+    # Reset the flow state
+    request.session['flow-state'] = None
+
     form = f.DatasetForm(request.POST or None)
     if request.method == 'POST':
         if form.is_valid():
@@ -91,6 +105,8 @@ def edit_dataset_details(request, dataset_name):
     if not user_can_edit_dataset(request.user, dataset):
         return HttpResponseForbidden()
 
+    _set_flow_state(request)
+
     form = f.EditDatasetForm(request.POST or None, instance=dataset)
     if request.method == 'POST':
         if form.is_valid():
@@ -116,6 +132,8 @@ def edit_organisation(request, dataset_name):
 
     if not user_can_edit_dataset(request.user, dataset):
         return HttpResponseForbidden()
+
+    _set_flow_state(request)
 
     organisations = organisations_for_user(request.user)
     if len(organisations) == 1:
@@ -148,6 +166,8 @@ def edit_licence(request, dataset_name):
     if not user_can_edit_dataset(request.user, dataset):
         return HttpResponseForbidden()
 
+    _set_flow_state(request)
+
     form = f.LicenceForm(request.POST or None, instance=dataset)
     if request.method == 'POST':
         if form.is_valid():
@@ -170,6 +190,8 @@ def edit_location(request, dataset_name):
     if not user_can_edit_dataset(request.user, dataset):
         return HttpResponseForbidden()
 
+    _set_flow_state(request)
+
     form = f.LocationForm(request.POST or None, instance=dataset)
     if request.method == 'POST':
         if form.is_valid():
@@ -191,6 +213,8 @@ def edit_frequency(request, dataset_name):
 
     if not user_can_edit_dataset(request.user, dataset):
         return HttpResponseForbidden()
+
+    _set_flow_state(request)
 
     form = f.FrequencyForm(request.POST or None, instance=dataset)
     if request.method == 'POST':
@@ -219,6 +243,8 @@ def edit_addfile(request, dataset_name, datafile_id=None):
 
     if not user_can_edit_dataset(request.user, dataset):
         return HttpResponseForbidden()
+
+    _set_flow_state(request)
 
     if request.method == 'POST':
         if form.is_valid():
@@ -268,6 +294,8 @@ def edit_addfile_weekly(request, dataset_name, datafile_id=None):
     if not user_can_edit_dataset(request.user, dataset):
         return HttpResponseForbidden()
 
+    _set_flow_state(request)
+
     if request.method == 'POST':
         if form.is_valid():
             data = dict(**form.cleaned_data)
@@ -303,6 +331,7 @@ def edit_addfile_monthly(request, dataset_name, datafile_id=None):
     if not user_can_edit_dataset(request.user, dataset):
         return HttpResponseForbidden()
 
+    _set_flow_state(request)
 
     if request.method == 'POST':
         if form.is_valid():
@@ -335,6 +364,8 @@ def edit_addfile_quarterly(request, dataset_name, datafile_id=None):
 
     if not user_can_edit_dataset(request.user, dataset):
         return HttpResponseForbidden()
+
+    _set_flow_state(request)
 
     if request.method == 'POST':
         if form.is_valid():
@@ -369,6 +400,8 @@ def edit_addfile_annually(request, dataset_name, datafile_id = None):
     if not user_can_edit_dataset(request.user, dataset):
         return HttpResponseForbidden()
 
+    _set_flow_state(request)
+
     if request.method == 'POST':
         if form.is_valid():
             data = dict(**form.cleaned_data)
@@ -401,6 +434,8 @@ def edit_files(request, dataset_name):
     if not user_can_edit_dataset(request.user, dataset):
         return HttpResponseForbidden()
 
+    _set_flow_state(request)
+
     return render(request, "datasets/show_files.html", {
         'addfile_viewname': url,
         'dataset': dataset,
@@ -419,6 +454,8 @@ def edit_add_doc(request, dataset_name, datafile_id=None):
 
     if not user_can_edit_dataset(request.user, dataset):
         return HttpResponseForbidden()
+
+    _set_flow_state(request)
 
     if request.method == 'POST':
         if form.is_valid():
@@ -450,6 +487,8 @@ def edit_documents(request, dataset_name):
     if not user_can_edit_dataset(request.user, dataset):
         return HttpResponseForbidden()
 
+    _set_flow_state(request)
+
     return render(request, "datasets/show_docs.html", {
         'dataset': dataset,
         'return_to': return_to,
@@ -464,6 +503,8 @@ def edit_notifications(request, dataset_name):
 
     if not user_can_edit_dataset(request.user, dataset):
         return HttpResponseForbidden()
+
+    _set_flow_state(request)
 
     if dataset.frequency in ['daily', 'never']:
         dataset.notifications = 'no'
@@ -498,6 +539,9 @@ def check_dataset(request, dataset_name):
 
     if not user_can_edit_dataset(request.user, dataset):
         return HttpResponseForbidden()
+
+    # Reset the flow state
+    request.session['flow-state'] = None
 
     organisation = dataset.organisation
     organisations = organisations_for_user(request.user)

--- a/src/publish_data/templates/main.html
+++ b/src/publish_data/templates/main.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 {% load static %}
-
+{% load flow_state %}
 
 {% block head %}
   <link rel="stylesheet" href="{% static 'css/main.css' %}"/>

--- a/src/publish_data/templatetags/flow_state.py
+++ b/src/publish_data/templatetags/flow_state.py
@@ -1,0 +1,18 @@
+from django import template
+
+register = template.Library()
+
+
+@register.filter
+def is_editing(request):
+    return request.session.get('flow-state') == 'editing'
+
+@register.filter
+def is_checking(request):
+    return request.session.get('flow-state') == 'checking'
+
+@register.filter
+def clear_flow_state(request):
+    previous = request.session.get('flow-state', '')
+    request.session['flow-state'] = None
+    return previous or ''


### PR DESCRIPTION
We're investigating whether we can cleanly remember the current state (editing or checking) without needing to pass around query string parameters.

Uses a template tag in the templates for determining if the current
request is editing or checking and allows for flow to be changed as a
result.  Typically this will look like

```
  {% load flow_state %}

  {% if request|is_editing %}
     Editing
  {% elif request|is_checking %}
     Checking
  {% else %}
     Neither
  {% endif %}

```

Each view function now includes a call to _set_flow_state which will set
the current state based on the presence of a state= query parameter.  If
it is missing then no change it made to the state value.