### PR TITLE
Enables tracking of events

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,13 @@ language: python
 python:
   - "3.5"
 install: "pip install -r requirements.txt"
-before_script: 
+before_script:
     - sleep 10
+    - psql -c 'create database travis_ci_test;' -U postgres
     - "cd src; python manage.py migrate; cd .."
 services:
     - elasticsearch
+    - postgresql
+addons:
+  postgresql: "9.4"
 script: "cd src; python manage.py test;"

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ sudo bash dev_setup.sh
 
 After a few minutes you should see the site at http://192.168.99.99:8000
 
-Alternatively to just run on your machine with Sqlite3 and Elastic search (v5)
+Alternatively to just run on your machine with Postgres and Elastic search (v5)
 
 
 ``` bash
@@ -30,6 +30,7 @@ git clone <REPO>
 cd publish_data_alpha
 pip install -r requirements.txt
 cd src
+export DATABASE_URL="postgres://username:password@localhost/databasename"
 export DJANGO_SETTINGS_MODULE="publish_data.settings.dev"
 export ES_HOSTS='127.0.0.1:9200'
 export ES_INDEX='data_discovery'

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ ckanapi==4.0
 boto==2.45.0
 django-oauth-toolkit==0.11
 requests_oauthlib==0.7.0
+django-papertrail==1.1.3

--- a/src/publish_data/settings/base.py
+++ b/src/publish_data/settings/base.py
@@ -43,6 +43,7 @@ REQUIRED_APPS = [
 ]
 
 PROJECT_APPS = [
+    'papertrail',
     'publish_data',
     'userauth',
     'datasets',

--- a/src/userauth/views.py
+++ b/src/userauth/views.py
@@ -3,6 +3,8 @@ from django.contrib.auth import authenticate, login, logout
 
 from .forms import SigninForm
 
+import papertrail
+
 
 def login_view(request):
     login_failed = False
@@ -15,6 +17,17 @@ def login_view(request):
             user = authenticate(username=email, password=password)
             if user is not None:
                 login(request, user)
+
+                papertrail.log(
+                    'login',
+                    '{} logged in'.format(user.username),
+                    data={
+                        'username': user.username,
+                        'email': user.email
+                    },
+                    external_key=user.email
+                )
+
                 return redirect("/")
             else:
                 login_failed = True


### PR DESCRIPTION
Uses django-papertrail to allow us to log specific events within
publish-data.  We can track logins, newly created datasets (and who by)
and deleted/published datasets etc.

Accessible currently only via the admin tool, but will form the basis of
publisher activity eventually.