### PR TITLE
Publish draft datasets from manage data

### DIFF
--- a/src/datasets/templates/datasets/check_dataset.html
+++ b/src/datasets/templates/datasets/check_dataset.html
@@ -174,7 +174,7 @@
       method="POST">
     {% csrf_token %}
     <div class="form-group">
-      <input type="submit" class="button" value="Accept">
+      <input type="submit" class="button" value="Publish">
       <a
           href="{% url 'delete_dataset' dataset.name %}"
           class="secondary-button">

--- a/src/publish_data/templates/manage.html
+++ b/src/publish_data/templates/manage.html
@@ -72,6 +72,9 @@
                 {% if dataset.name %}
                   <a href="{% url 'edit_dataset_addfile' dataset.name %}">Add&nbsp;Data</a><br/>
                   <a href="{% url 'edit_full_dataset' dataset.name %}">Edit</a><br/>
+                  {% if not dataset.published %}
+                      <a href="{% url 'edit_dataset_check_dataset' dataset.name %}">Publish</a><br/>
+                  {% endif %}
                 {% endif %}
               </td>
             </tr>


### PR DESCRIPTION
If a dataset is a draft, adds a link to go to check_dataset so user can
publish. (Temporary measure).

Renamed Accept on check_dataset to Publish as per @maria-izquierdo 