### PR TITLE
Give dashboard it's own URL

### DIFF
--- a/src/publish_data/settings/base.py
+++ b/src/publish_data/settings/base.py
@@ -147,7 +147,7 @@ USE_L10N = True
 USE_TZ = True
 
 LOGIN_URL = '/accounts/signin'
-
+LOGIN_REDIRECT_URL = '/dashboard'
 
 HOMEPAGE_URL = '/'
 LOGO_LINK_TITLE = 'Go to the data.gov.uk homepage'

--- a/src/publish_data/templates/main_with_navbar.html
+++ b/src/publish_data/templates/main_with_navbar.html
@@ -33,11 +33,11 @@
         <div id="side-navigation">
           <nav>
             <ul>
-              {% url 'home' as home %}
+              {% url 'dashboard' as dashboard %}
               {% url 'new_dataset' as new %}
               {% url 'manage_data' as manage %}
-              <li class="{% if request.path == home %}bold{% endif %}">
-                <a href="{{ home }}">Dashboard</a>
+              <li class="{% if request.path == dashboard %}bold{% endif %}">
+                <a href="{{ dashboard }}">Dashboard</a>
               </li>
               <li class="{% if request.path == new %}bold{% endif %}">
                 <a href="{{ new }}">Create a dataset</a>

--- a/src/publish_data/tests/test_toplevelviews.py
+++ b/src/publish_data/tests/test_toplevelviews.py
@@ -21,15 +21,15 @@ class TopLevelViewsCase(TestCase):
         assert 'You must create an account to use this service' in \
             str(response.content)
 
-    def test_homepage_is_dashboard_when_logged_in(self):
+    def test_homepage_redirects_to_dashboard_when_logged_in(self):
         response = self.client.post('/accounts/signin', {
             'email': self.test_user.email,
             'password': 'password'
         })
         assert response.status_code == 302
-        assert response.url == '/'
+        assert response.url == '/dashboard', response.url
 
-        response = self.client.get('/')
+        response = self.client.get('/dashboard')
         assert 'Dashboard' in str(response.content)
 
     def test_manage_redirects(self):
@@ -43,7 +43,7 @@ class TopLevelViewsCase(TestCase):
             'password': 'password'
         })
         assert response.status_code == 302
-        assert response.url == '/'
+        assert response.url == '/dashboard'
 
         response = self.client.get('/manage')
         assert response.status_code == 200

--- a/src/publish_data/urls.py
+++ b/src/publish_data/urls.py
@@ -9,6 +9,7 @@ urlpatterns = [
     url(r'^admin/', include(admin.site.urls)),
 
     url(r'^$', views.home, name='home'),
+    url(r'^dashboard$', views.dashboard, name='dashboard'),
     url(r'^cookies$', TemplateView.as_view(template_name='cookies.html'), name='cookies'),
     url(r'manage$', views.manage_data, name='manage_data'),
     url(r'^accounts/', include('userauth.urls')),

--- a/src/publish_data/views.py
+++ b/src/publish_data/views.py
@@ -1,4 +1,6 @@
+from django.http import HttpResponseRedirect
 from django.contrib.auth.decorators import login_required
+from django.urls import reverse
 from django.shortcuts import render
 from django.conf import settings
 
@@ -9,7 +11,8 @@ from runtime_config.logic import get_config
 
 def home(request):
     if request.user.is_authenticated():
-        return dashboard(request)
+        return HttpResponseRedirect(reverse('dashboard'))
+
     return render(request, "home.html", {})
 
 

--- a/src/userauth/tests/test_signin.py
+++ b/src/userauth/tests/test_signin.py
@@ -22,7 +22,7 @@ class SigninTestCase(TestCase):
             "password": "password"
         })
         assert response.status_code == 302
-        assert response.url == '/'
+        assert response.url == '/dashboard'
 
     def test_signin_fail(self):
         response = self.client.post(reverse('signin'), {

--- a/src/userauth/tests/test_signout.py
+++ b/src/userauth/tests/test_signout.py
@@ -23,7 +23,7 @@ class SignoutTestCase(TestCase):
             "password": "password"
         })
         assert response.status_code == 302
-        assert response.url == '/'
+        assert response.url == '/dashboard'
 
         response = self.client.post(reverse('signout'), {})
         assert response.status_code == 302

--- a/src/userauth/views.py
+++ b/src/userauth/views.py
@@ -1,5 +1,6 @@
 from django.shortcuts import render, redirect
 from django.contrib.auth import authenticate, login, logout
+from django.conf import settings
 
 from .forms import SigninForm
 
@@ -28,7 +29,9 @@ def login_view(request):
                     external_key=user.email
                 )
 
-                return redirect("/")
+                # TODO: Handle next parameter and redirect there...
+
+                return redirect(settings.LOGIN_REDIRECT_URL)
             else:
                 login_failed = True
 


### PR DESCRIPTION
Currently / will render the dashboard if you are logged in, and the
homepage if not, which will skew our GA data.  Instead, let's have a
specific place for dashboard at /dashboard