### PR TITLE
Fix organisation saving for admins

### DIFF
--- a/src/datasets/views.py
+++ b/src/datasets/views.py
@@ -182,7 +182,7 @@ def edit_organisation(request, dataset_name):
         return _redirect_to(request, 'edit_dataset_licence', [dataset.name])
 
     form = f.OrganisationForm(request.POST or None, instance=dataset)
-    form.fields["organisation"].queryset = request.user.organisations.all()
+    form.fields["organisation"].queryset = organisations_for_user(request.user)
 
     if request.method == 'POST':
         if form.is_valid():


### PR DESCRIPTION
When logged in as an admin we want to allow them to save organisations.
This means we can't use the django ORM relationship and we should use
the organisations_for_user helper instead.

Fixes #254