### PR TITLE
Show non-organisation, but owned datasets in manage_data

### DIFF
--- a/src/datasets/logic.py
+++ b/src/datasets/logic.py
@@ -1,5 +1,6 @@
 import math
 
+from django.db.models import Q
 from datasets.models import Dataset, Organisation
 
 
@@ -13,15 +14,14 @@ def dataset_list(user, page=1, filter_query=None):
     """
     For the given user returns a tuple containing total number of datasets
     both draft and published, and the 20 most recent.
-
-    TODO: Get this from a search index.
     """
     per_page = 20
     max_fetch = per_page * page
 
     organisations = organisations_for_user(user)
+    sub_query = Q(organisation__in=organisations) | Q(creator=user)
     q = Dataset.objects\
-        .filter(organisation__in=organisations)
+        .filter(sub_query)
 
     if filter_query:
         q = q.filter(title__icontains=filter_query)


### PR DESCRIPTION
As organisation will soon be optional, we need to support showing drafts
datasets that may not have an organisation attached.  For this we need
to make sure that the dataset list shows datasets when the user is a
member, OR where the user is the creator (which makes it a personal
draft, rather than a team draft).

Fixes #267