### PR TITLE
Never skip organisations page

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ After a few minutes you should see the site at http://192.168.99.99:8000
 
 Alternatively to just run on your machine with Postgres and Elastic search (v5)
 
-
 ``` bash
 # Make and active a virtualenv for Python 3
 git clone <REPO>

--- a/src/datasets/views.py
+++ b/src/datasets/views.py
@@ -119,10 +119,6 @@ def edit_organisation(request, dataset_name):
     _set_flow_state(request)
 
     organisations = organisations_for_user(request.user)
-    if len(organisations) == 1:
-        dataset.organisation = organisations[0]
-        dataset.save()
-        return _redirect_to(request, 'edit_dataset_licence', [dataset.name])
 
     form = f.OrganisationForm(request.POST or None, instance=dataset)
     form.fields["organisation"].queryset = organisations_for_user(request.user)


### PR DESCRIPTION
Previously if user was only in one organisation, we skipped it. Now we
expect them to choose it and it will act as a clear indication that they
might not be publishing for the correct organisation.

Fixes #293