### PR TITLE
Reset flow state when not editing a dataset

### DIFF
--- a/src/publish_data/middleware.py
+++ b/src/publish_data/middleware.py
@@ -42,3 +42,21 @@ class BasicAuthenticationMiddleware(object):
             return response
 
         return basic_challenge()
+
+class ResetFlowMiddleware(object):
+    ''' To avoid having to reset the session for the flow state in various
+    places, this will reset it when the request is not to /static or /dataset
+    '''
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        path = request.path
+        reset = True
+
+        if not (path.startswith(settings.STATIC_URL) or
+                path.startswith('/dataset')):
+            request.session['flow-state'] = None
+
+        return self.get_response(request)
+

--- a/src/publish_data/settings/base.py
+++ b/src/publish_data/settings/base.py
@@ -68,6 +68,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'publish_data.middleware.ResetFlowMiddleware'
 ]
 
 ROOT_URLCONF = 'publish_data.urls'

--- a/src/publish_data/views.py
+++ b/src/publish_data/views.py
@@ -23,8 +23,6 @@ def dashboard(request):
     # Use an actual organisation for this user
     stats = get_stats("cabinet-office", _("Downloads"))
 
-    request.session['flow-state'] = None
-
     return render(request, "dashboard.html", {
         "tasks": tasks,
         "stats": stats
@@ -33,8 +31,6 @@ def dashboard(request):
 
 @login_required()
 def manage_data(request):
-    request.session['flow-state'] = None
-
     q = request.GET.get('q')
     result = request.GET.get('result')
 


### PR DESCRIPTION
To avoid setting the flow state to None in all non-editing views, we
instead will do this in middleware.  We reset the state on any request
to non-static or non /dataset/* urls.

Fixes #282 