### PR TITLE
retrieve stats and show them on dashboard

### DIFF
--- a/src/assets/javascripts/app.js
+++ b/src/assets/javascripts/app.js
@@ -134,10 +134,63 @@
     },
   };
 
+  var dashboardStats = {
+
+    fetchStats: function() {
+      $.get(this.endpoint + 'stats/?orgs=' + this.orgs.join())
+        .done($.proxy(this.makeStatsMarkup, this))
+        .fail(function(xhr, text, error) {
+          console.log('fail: ', text, error);
+        })
+    },
+
+    statText: function(stat) {
+      switch(stat.statistic) {
+        // TODO: make it easier to translate the text
+        case 'view': return 'Views: ' + stat.total;
+        case 'download': return 'Downloads: ' + stat.total;
+        case 'search': return 'Searched: ' + stat.total;
+        default: return '';
+      }
+    },
+
+    makeStatsMarkup: function(data) {
+      var $tbody = this.$statsSection.find('table tbody');
+      var $rowTemplate = $('#row-template');
+      $.each(data, function(index, datum) {
+        var $newRow = $rowTemplate.clone().removeAttr('id style');
+        var statText = dashboardStats.statText(datum);
+        if (datum.dataset_title && statText) {
+          $newRow
+            .find('.stats-title')
+            .text(datum.dataset_title);
+          $newRow
+            .find('.stats-downloads')
+            .text(statText);
+          $tbody.append($newRow);
+        }
+      });
+      this.$statsSection.removeClass('js-hidden');
+    },
+
+    init: function(selector) {
+      this.$statsSection = $(selector);
+      if (this.$statsSection) {
+        this.endpoint = $('#api-endpoint').text();
+        this.orgs = JSON.parse($('#orgs').text());
+        if (this.endpoint.length && this.orgs.length) {
+          this.fetchStats();
+        }
+      }
+    }
+  };
+
+
 
   $(document).ready(function() {
     tableShowHide.init({ rowLimit: 3});
     typeAhead.init({ selector: '.location-input' });
+    dashboardStats.init('#dashboard-stats');
   });
 
 })();

--- a/src/assets/js/main.js
+++ b/src/assets/js/main.js
@@ -725,10 +725,63 @@ if (!Function.prototype.bind) {
     },
   };
 
+  var dashboardStats = {
+
+    fetchStats: function() {
+      $.get(this.endpoint + 'stats/?orgs=' + this.orgs.join())
+        .done($.proxy(this.makeStatsMarkup, this))
+        .fail(function(xhr, text, error) {
+          console.log('fail: ', text, error);
+        })
+    },
+
+    statText: function(stat) {
+      switch(stat.statistic) {
+        // TODO: make it easier to translate the text
+        case 'view': return 'Views: ' + stat.total;
+        case 'download': return 'Downloads: ' + stat.total;
+        case 'search': return 'Searched: ' + stat.total;
+        default: return '';
+      }
+    },
+
+    makeStatsMarkup: function(data) {
+      var $tbody = this.$statsSection.find('table tbody');
+      var $rowTemplate = $('#row-template');
+      $.each(data, function(index, datum) {
+        var $newRow = $rowTemplate.clone().removeAttr('id style');
+        var statText = dashboardStats.statText(datum);
+        if (datum.dataset_title && statText) {
+          $newRow
+            .find('.stats-title')
+            .text(datum.dataset_title);
+          $newRow
+            .find('.stats-downloads')
+            .text(statText);
+          $tbody.append($newRow);
+        }
+      });
+      this.$statsSection.removeClass('js-hidden');
+    },
+
+    init: function(selector) {
+      this.$statsSection = $(selector);
+      if (this.$statsSection) {
+        this.endpoint = $('#api-endpoint').text();
+        this.orgs = JSON.parse($('#orgs').text());
+        if (this.endpoint.length && this.orgs.length) {
+          this.fetchStats();
+        }
+      }
+    }
+  };
+
+
 
   $(document).ready(function() {
     tableShowHide.init({ rowLimit: 3});
     typeAhead.init({ selector: '.location-input' });
+    dashboardStats.init('#dashboard-stats');
   });
 
 })();

--- a/src/publish_data/templates/dashboard.html
+++ b/src/publish_data/templates/dashboard.html
@@ -64,8 +64,10 @@
       </table>
     </section>
 
-    <h2 class="heading-medium">{% trans "Most popular" %}</h2>
-    <div>
+    <div id="dashboard-stats" class="js-hidden">
+      <div id="orgs" style="display: none">{{ orgs }}</div>
+      <div id="api-endpoint" style="display: none">{{ api_endpoint }}</div>
+      <h2 class="heading-medium">{% trans "Most popular" %}</h2>
       <table>
         <thead>
           <tr>
@@ -74,23 +76,15 @@
           </tr>
         </thead>
         <tbody>
-          {% for stat in stats %}
-            <tr class="clickable-row">
-              <td>{{ stat.dataset_title}}</td>
-              <td>
-                <span class="nb-downloads">{{ stat.value }}</span>
-                <div class="text-supporting">
-                  <span class="data-neutral-arrow">
-                    {% if stat.direction == "up"%}&#9650;{%endif%}
-                    {% if stat.direction == "down"%}&#9660;{%endif%}
-                  </span>
-                  {{ stat.since }}
-                </div>
-              </td>
-            </tr>
-          {% endfor %}
+          <tr id="row-template" style="display: none">
+            <td class="stats-title"></td>
+            <td>
+              <span class="stats-downloads"></span>
+            </td>
+          </tr>
         </tbody>
       </table>
     </div>
+
   </div>
 {% endblock %}

--- a/src/publish_data/views.py
+++ b/src/publish_data/views.py
@@ -1,3 +1,6 @@
+import os
+import json
+
 from django.http import HttpResponseRedirect
 from django.contrib.auth.decorators import login_required
 from django.urls import reverse
@@ -5,7 +8,7 @@ from django.shortcuts import render
 from django.conf import settings
 from django.utils.translation import ugettext as _
 
-from datasets.logic import dataset_list
+from datasets.logic import dataset_list, organisations_for_user
 from tasks.logic import get_tasks_for_user
 from stats.logic import get_stats
 from runtime_config.logic import get_config
@@ -20,10 +23,14 @@ def home(request):
 @login_required()
 def dashboard(request):
     tasks = get_tasks_for_user(request.user)
+    organisations = organisations_for_user(request.user)
+
     # Use an actual organisation for this user
     stats = get_stats("cabinet-office", _("Downloads"))
 
     return render(request, "dashboard.html", {
+        "orgs": json.dumps([str(o.id) for o in organisations]),
+        "api_endpoint": os.environ.get('FIND_URL') or '',
         "tasks": tasks,
         "stats": stats
     })


### PR DESCRIPTION
JS will create and populate table on dashboard with stats retrieved from find-data.
More things to be done in the future (when we have more data)
- general presentation
- trends over a certain period
- grouping of types of stat (download, view, search) by dataset title