### PR TITLE
Use factoryboy to simplify test setup

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ boto==2.45.0
 django-oauth-toolkit==0.11
 requests_oauthlib==0.7.0
 django-papertrail==1.1.3
+factory_boy==2.8.1

--- a/src/datasets/tests/__init__.py
+++ b/src/datasets/tests/__init__.py
@@ -10,3 +10,5 @@ import datasets.views as v
 v.show_weekly_frequency = _show_weekly_for_test
 
 
+def setup():
+    print("Setting up test data for 'datasets'")

--- a/src/datasets/tests/factories.py
+++ b/src/datasets/tests/factories.py
@@ -1,0 +1,56 @@
+import factory
+from factory.django import DjangoModelFactory
+
+
+from django.contrib.auth import get_user_model
+
+class OrganisationFactory(DjangoModelFactory):
+    class Meta:
+        model = 'datasets.organisation'
+        django_get_or_create = ('name',)
+
+    name='test-org',
+    title='Test Organisation',
+    description='Test Organisation Description'
+
+
+class DatasetFactory(DjangoModelFactory):
+    class Meta:
+        model = 'datasets.dataset'
+        django_get_or_create = ('name',)
+
+    name = 'a-test-dataset'
+    title = 'A test dataset'
+    summary = 'A test summary'
+    frequency = 'weekly'
+    organisation_id = ''
+
+class DatafileFactory(DjangoModelFactory):
+    class Meta:
+        model = 'datasets.datafile'
+        django_get_or_create = ('url', 'dataset')
+
+    title = 'A test file'
+    url = 'https://data.gov.uk'
+    format = 'HTML'
+    dataset = None
+
+
+class GoodUserFactory(DjangoModelFactory):
+    class Meta:
+        model = get_user_model()
+        django_get_or_create = ('username',)
+
+    username = 'test-safe-user'
+    email = 'test-safe-user@localhost'
+    password = 'password'
+
+
+class NaughtyUserFactory(DjangoModelFactory):
+    class Meta:
+        model = get_user_model()
+        django_get_or_create = ('username',)
+
+    username="Naughty Test User Signin",
+    email="naughty-user@localhost",
+

--- a/src/datasets/tests/test_auth.py
+++ b/src/datasets/tests/test_auth.py
@@ -6,23 +6,20 @@ from django.urls import reverse
 from datasets.models import Dataset, Organisation, Datafile
 from datasets.auth import user_can_edit_dataset, user_can_edit_datafile
 
+from .factories import (GoodUserFactory,
+                        NaughtyUserFactory,
+                        OrganisationFactory,
+                        DatasetFactory,
+                        DatafileFactory)
 
 class AuthTestCase(TestCase):
 
     def setUp(self):
-        self.test_user = get_user_model().objects.create(
-            email="test-signin@localhost",
-            username="Test User Signin",
-            apikey=str(uuid.uuid4())
-        )
+        self.test_user = GoodUserFactory.create()
         self.test_user.set_password("password")
         self.test_user.save()
 
-        self.naughty_user = get_user_model().objects.create(
-            email="naughty-user@localhost",
-            username="Naughty Test User Signin",
-            apikey=str(uuid.uuid4())
-        )
+        self.naughty_user = NaughtyUserFactory.create()
 
         self.organisation = Organisation.objects.create(
             name='test-org',
@@ -33,43 +30,18 @@ class AuthTestCase(TestCase):
 
         # Log the user in
         self.client.post(reverse('signin'), {
-            "email": "test-signin@localhost",
+            "email": self.test_user.email,
             "password": "password"
         })
 
         # Both test the initial dataset creation, and get a name we can
         # use for the remaining tests.
-        self.dataset_name = self._create_new_dataset()
-        self.dataset = Dataset.objects.get(name=self.dataset_name)
+        self.dataset = DatasetFactory.create()
         self.dataset.organisation = self.organisation
         self.dataset.save()
 
-        self.datafile = Datafile.objects.create(
-            title="A test file",
-            url="https://data.gov.uk",
-            format="HTML",
-            dataset=self.dataset)
+        self.datafile = DatafileFactory.create(dataset=self.dataset)
 
-
-
-    def _create_new_dataset(self):
-        response = self.client.post(reverse('new_dataset', args=[]), {
-                'title': 'A test dataset for create',
-                'description': 'A test description',
-                'summary': 'A test summary',
-        })
-        assert response.status_code == 302
-
-        parts = response.url.split('/')
-        name = parts[2]
-
-        # Set frequency
-        response = self.client.post(reverse('edit_dataset_frequency', args=[name]), {
-                'frequency': 'weekly',
-        })
-        assert response.status_code == 302
-
-        return name
 
     def test_user_has_access(self):
         can = user_can_edit_dataset(self.test_user, self.dataset)

--- a/src/datasets/tests/test_create.py
+++ b/src/datasets/tests/test_create.py
@@ -5,53 +5,25 @@ from django.contrib.auth import get_user_model
 from django.urls import reverse
 from datasets.models import Dataset, Organisation
 
-
+from .factories import (GoodUserFactory,
+                        NaughtyUserFactory,
+                        OrganisationFactory,
+                        DatasetFactory,
+                        DatafileFactory)
 
 class DatasetsTestCase(TestCase):
 
     def setUp(self):
-        self.test_user = get_user_model().objects.create(
-            email="test-signin@localhost",
-            username="test-signin@localhost",
-            apikey=str(uuid.uuid4())
-        )
+        self.test_user = GoodUserFactory.create()
         self.test_user.set_password("password")
         self.test_user.save()
-
-        self.organisation = Organisation.objects.create(
-            name='test-org',
-            title='Test Organisation',
-            description='Test Organisation Description'
-        )
+        self.organisation = OrganisationFactory.create()
         self.organisation.users.add(self.test_user)
-
-        self.client.login(username='test-signin@localhost', password='password')
-
-        # Both test the initial dataset creation, and get a name we can
-        # use for the remaining tests.
-        self.dataset_name = self._create_new_dataset()
-
-    def _create_new_dataset(self):
-        response = self.client.post(reverse('new_dataset', args=[]), {
-                'title': 'A test dataset for create',
-                'description': 'A test description',
-                'summary': 'A test summary',
-        })
-        assert response.status_code == 302
-
-        parts = response.url.split('/')
-        name = parts[2]
-
-        # Set frequency
-        response = self.client.post(reverse('edit_dataset_frequency', args=[name]), {
-                'frequency': 'weekly',
-        })
-        assert response.status_code == 302
-
-        return name
+        self.client.login(username=self.test_user.email, password='password')
+        self.dataset = DatasetFactory.create(organisation_id=self.organisation.id)
 
     def _get_dataset(self):
-        return Dataset.objects.get(name=self.dataset_name)
+        return Dataset.objects.get(name=self.dataset.name)
 
     def test_bad_slug(self):
         response = self.client.post(reverse('new_dataset', args=[]), {
@@ -69,16 +41,18 @@ class DatasetsTestCase(TestCase):
         assert response.status_code == 200
 
     def test_location(self):
-        u = reverse('edit_dataset_location', args=[self.dataset_name])
+        u = reverse('edit_dataset_location', args=[self.dataset.name])
         response = self.client.get(u)
         assert response.status_code == 200
 
         # No selected countries
         response = self.client.post(u, {})
         assert response.status_code == 200
-        assert self._get_dataset().location1 == ''
-        assert self._get_dataset().location2 == ''
-        assert self._get_dataset().location3 == ''
+
+        ds = self._get_dataset()
+        assert ds.location1 == ''
+        assert ds.location2 == ''
+        assert ds.location3 == ''
 
         response = self.client.post(
             u,
@@ -89,7 +63,7 @@ class DatasetsTestCase(TestCase):
             self._get_dataset().location1
 
     def test_licence(self):
-        u = reverse('edit_dataset_licence', args=[self.dataset_name])
+        u = reverse('edit_dataset_licence', args=[self.dataset.name])
         response = self.client.get(u)
         assert response.status_code == 200
 
@@ -118,7 +92,7 @@ class DatasetsTestCase(TestCase):
         assert obj.licence_other == "pretend licence"
 
     def test_frequency(self):
-        u = reverse('edit_dataset_frequency', args=[self.dataset_name])
+        u = reverse('edit_dataset_frequency', args=[self.dataset.name])
         response = self.client.get(u)
         assert response.status_code == 200
 
@@ -136,7 +110,7 @@ class DatasetsTestCase(TestCase):
     def test_organisation(self):
         u = reverse(
             'edit_dataset_organisation',
-            args=[self.dataset_name]
+            args=[self.dataset.name]
         )
         # With only a single organisation, we expect a redirect
         response = self.client.get(u)
@@ -153,26 +127,25 @@ class DatasetsTestCase(TestCase):
             }
         )
         assert response.status_code == 302
-        assert self._get_dataset().organisation.name == "test-org", \
-            self._get_dataset().organisation
+        assert self._get_dataset().organisation.id == self.organisation.id
 
 
     def test_redirect_adding_extra_file(self):
-        u = reverse('edit_dataset_files', args=[self.dataset_name])
+        u = reverse('edit_dataset_files', args=[self.dataset.name])
         response = self.client.get(u)
         assert response.status_code == 200
-        assert '/dataset/{}/addfile_weekly'.format(self.dataset_name) in response.content.decode('utf-8')
+        assert '/dataset/{}/addfile_weekly'.format(self.dataset.name) in response.content.decode('utf-8')
 
 
     def test_frequency_details(self):
-        u = reverse('edit_dataset_frequency', args=[self.dataset_name])
+        u = reverse('edit_dataset_frequency', args=[self.dataset.name])
         response = self.client.post(
             u,
             {'frequency': 'weekly'}
         )
         assert response.status_code == 302
         assert response.url == reverse('edit_dataset_addfile_weekly',
-            args=[self.dataset_name])
+            args=[self.dataset.name])
 
         response = self.client.post(
             u,
@@ -180,7 +153,7 @@ class DatasetsTestCase(TestCase):
         )
         assert response.status_code == 302
         assert response.url == reverse('edit_dataset_addfile_monthly',
-            args=[self.dataset_name])
+            args=[self.dataset.name])
 
         response = self.client.post(
             u,
@@ -188,7 +161,7 @@ class DatasetsTestCase(TestCase):
         )
         assert response.status_code == 302
         assert response.url == reverse('edit_dataset_addfile_quarterly',
-            args=[self.dataset_name])
+            args=[self.dataset.name])
 
         response = self.client.post(
             u,
@@ -196,7 +169,7 @@ class DatasetsTestCase(TestCase):
         )
         assert response.status_code == 302
         assert response.url == reverse('edit_dataset_addfile_annually',
-            args=[self.dataset_name])
+            args=[self.dataset.name])
 
         #response = self.client.post(
         #    u,
@@ -206,19 +179,19 @@ class DatasetsTestCase(TestCase):
         #)
         #assert response.status_code == 302
         #assert response.url == reverse('edit_dataset_step-year',
-        #    args=[self.dataset_name, 'frequency_financial_year'])
+        #    args=[self.dataset.name, 'frequency_financial_year'])
 
     def test_adddoc(self):
         u = reverse(
             'edit_dataset_adddoc',
-            args=[self.dataset_name]
+            args=[self.dataset.name]
         )
         response = self.client.get(u)
-        assert response.status_code == 200
+        assert response.status_code == 200, response.status_code
 
         # Assert an error
         response = self.client.post(u, {})
-        assert response.status_code == 200
+        assert response.status_code == 200, response.status_code
 
         response = self.client.post(
             u,
@@ -230,13 +203,13 @@ class DatasetsTestCase(TestCase):
         assert response.status_code == 302
         assert response.url == reverse(
             'edit_dataset_documents',
-            args=[self.dataset_name]
+            args=[self.dataset.name]
         )
 
     def test_notifications(self):
         u = reverse(
             'edit_dataset_notifications',
-            args=[self.dataset_name]
+            args=[self.dataset.name]
         )
         response = self.client.get(u)
         assert response.status_code == 200
@@ -257,7 +230,7 @@ class DatasetsTestCase(TestCase):
     def test_check(self):
         u = reverse(
             'publish_dataset',
-            args=[self.dataset_name]
+            args=[self.dataset.name]
         )
         response = self.client.get(u)
         assert response.status_code == 200
@@ -265,7 +238,7 @@ class DatasetsTestCase(TestCase):
     def test_addfile(self):
         u = reverse(
             'edit_dataset_addfile_weekly',
-            args=[self.dataset_name]
+            args=[self.dataset.name]
         )
         response = self.client.get(u)
         assert response.status_code == 200
@@ -295,6 +268,6 @@ class DatasetsTestCase(TestCase):
         assert response.status_code == 200
 
     def test_showfiles(self):
-        u = reverse('edit_dataset_files', args=[self.dataset_name])
+        u = reverse('edit_dataset_files', args=[self.dataset.name])
         response = self.client.get(u)
         assert response.status_code == 200

--- a/src/datasets/tests/test_datafile_dates.py
+++ b/src/datasets/tests/test_datafile_dates.py
@@ -5,7 +5,11 @@ from django.contrib.auth import get_user_model
 from django.urls import reverse
 from datasets.models import Dataset, Datafile
 
-
+from .factories import (GoodUserFactory,
+                        NaughtyUserFactory,
+                        OrganisationFactory,
+                        DatasetFactory,
+                        DatafileFactory)
 
 class DatafileDatesTestCase(TestCase):
     """ Test that when we save the start/end dates are set
@@ -13,10 +17,7 @@ class DatafileDatesTestCase(TestCase):
     """
 
     def setUp(self):
-        self.dataset = Dataset.objects.create(
-            title='a test dataset'
-        )
-
+        self.dataset = DatasetFactory.create()
 
     def skeleton(self):
         return Datafile(

--- a/src/datasets/tests/test_misc.py
+++ b/src/datasets/tests/test_misc.py
@@ -7,7 +7,7 @@ class MiscTestCase(TestCase):
 
 
     def test_url_exists_ok(self):
-        exists, fmt, error = url_exists('https://data.gov.uk')
+        exists, fmt, error = url_exists('https://google.com')
         assert exists
         assert fmt == 'HTML', fmt
         assert not error

--- a/src/datasets/tests/test_organisation.py
+++ b/src/datasets/tests/test_organisation.py
@@ -7,22 +7,20 @@ from django.urls import reverse
 from datasets.models import Organisation
 from datasets.logic import organisations_for_user
 
+from .factories import (GoodUserFactory,
+                        NaughtyUserFactory,
+                        OrganisationFactory,
+                        DatasetFactory,
+                        DatafileFactory)
+
 class OrganisationTestCase(TestCase):
 
     def setUp(self):
-        self.test_user = get_user_model().objects.create(
-            email="test-signin@localhost",
-            username="Test User Signin",
-            apikey=str(uuid.uuid4())
-        )
+        self.test_user = GoodUserFactory.create()
         self.test_user.set_password("password")
         self.test_user.save()
 
-        self.organisation = Organisation.objects.create(
-            name='cabinet-office',
-            title='Cabinet Office',
-            description='Description'
-        )
+        self.organisation = OrganisationFactory.create()
         self.organisation.users.add(self.test_user)
 
 

--- a/src/publish_data/templatetags/form_controls.py
+++ b/src/publish_data/templatetags/form_controls.py
@@ -8,7 +8,7 @@ register = template.Library()
 def form_controls(request, dataset_name):
 
     page = request.resolver_match.url_name
-    state = request.session['flow-state']
+    state = request.session.get('flow-state')
 
     if state in ['checking', 'editing']:
         params = {


### PR DESCRIPTION
Allows us to define factory objects for various instances of the various types so we're not recreating the objects in each setup call.  We are though calling FactoryBoy a lot in each setup call. This does marginally increase test speed, and makes the test object creation a bit easier.

Updated requirements

Drive-by update. Replace a request.session[] call with request.session.get() in form_controls

Fixes #300 