### PR TITLE
Allow sorting of manage_data results.

### DIFF
--- a/src/datasets/logic.py
+++ b/src/datasets/logic.py
@@ -19,7 +19,7 @@ def publish(dataset, user):
         unindex_dataset(dataset)
 
 
-def dataset_list(user, page=1, filter_query=None):
+def dataset_list(user, page=1, filter_query=None, sort=None):
     """
     For the given user returns a tuple containing total number of datasets
     both draft and published, and the 20 most recent.
@@ -35,7 +35,10 @@ def dataset_list(user, page=1, filter_query=None):
     if filter_query:
         q = q.filter(title__icontains=filter_query)
 
-    q = q.order_by('-last_edit_date')
+    if not sort:
+        q = q.order_by('-last_edit_date')
+    else:
+        q = q.order_by(sort)
 
     start = (per_page * page) - per_page
     datasets = q.all()[start:start+per_page]

--- a/src/publish_data/views.py
+++ b/src/publish_data/views.py
@@ -40,6 +40,7 @@ def dashboard(request):
 def manage_data(request):
     q = request.GET.get('q')
     result = request.GET.get('result')
+    sort = request.GET.get('sort')
 
     page = 1
     try:
@@ -47,8 +48,11 @@ def manage_data(request):
     except:
         page = 1
 
+    if sort and not sort in ['name', 'published', '-name', '-published']:
+        sort = None
+
     total, page_count, datasets = dataset_list(
-        request.user, page, filter_query=q
+        request.user, page, filter_query=q, sort=sort
     )
 
     ckan_host = get_config('ckan.host') or ''


### PR DESCRIPTION
Passing a sort parameter to the page will sort the results by that
parameter, otherwise by most recent first.

Allow values for sort are:

name, -name, published, -published

We might want to change published to status if we want prettier
parameters