### PR TITLE
Promote org name to top level of indexed dict

### DIFF
--- a/src/datasets/models.py
+++ b/src/datasets/models.py
@@ -98,6 +98,7 @@ class Dataset(models.Model):
             'update_frequency': self.frequency,
             'last_edit_date': self.last_edit_date.isoformat(),
             'published_date': self.published_date.isoformat() if self.published_date else '',
+            'organisation_name': self.organisation.name,
             'organisation': self.organisation.as_dict(),
             'resources': [f.as_dict() for f in self.files.filter(is_documentation=False).all()],
             'documentation': [f.as_dict() for f in self.files.filter(is_documentation=True).all()],
@@ -184,8 +185,8 @@ class Datafile(models.Model):
             'title': self.title,
             'url': self.url,
             'format': self.format,
-            'start_date': start.isoformat() if start else '',
-            'end_date': end.isoformat() if end else '',
+            'start_date': start.isoformat() if start else None,
+            'end_date': end.isoformat() if end else None,
             'is_broken': self.is_broken
         }
 

--- a/src/datasets/search.py
+++ b/src/datasets/search.py
@@ -17,7 +17,7 @@ es.indices.create(
             "datasets" : {
                 "properties" : {
                     "name" : { "type": "string", "index" : "not_analyzed" },
-                    "organisation.name" : { "type": "string", "index" : "not_analyzed" }
+                    "organisation_name" : { "type": "string", "index" : "not_analyzed" }
                 }
             }
           },


### PR DESCRIPTION
Because we want to match directly against the org name, we'll promote it to top level to make the search easier in find-data.