### PR TITLE
Speculative splitting of My Tasks and Org tasks.

### DIFF
--- a/src/publish_data/urls.py
+++ b/src/publish_data/urls.py
@@ -14,7 +14,7 @@ urlpatterns = [
     url(r'manage$', views.manage_data, name='manage_data'),
     url(r'^accounts/', include('userauth.urls')),
     url(r'^dataset/',  include('datasets.urls')),
-    url(r'^task/',  include('tasks.urls')),
+    url(r'^tasks/',  include('tasks.urls')),
     url(r'^api/',  include('api.urls')),
 
     url(r'^o/', include('oauth2_provider.urls', namespace='oauth2_provider')),

--- a/src/tasks/logic.py
+++ b/src/tasks/logic.py
@@ -25,6 +25,22 @@ def get_tasks_for_user(user):
 
     return tasks
 
+def get_tasks_for_organisation(organisation):
+    """ For the given organisation name, find the tasks that
+        they have in each category
+    """
+    orgs = [organisation]
+    user_permissions = [""]
+    task_objs = Task.objects\
+        .filter(owning_organisation__in=orgs)\
+        .filter(required_permission_name__in=user_permissions)\
+        .all()
+
+    tasks = {}
+    for entry in TASK_CATEGORIES:
+        tasks[entry[0]] = [t for t in task_objs if t.category == entry[0]]
+
+    return tasks
 
 def user_ignore_task(user, task):
     """

--- a/src/tasks/templates/tasks/base.html
+++ b/src/tasks/templates/tasks/base.html
@@ -1,0 +1,94 @@
+{% extends 'main.html' %}
+{% load static %}
+{% load i18n %}
+
+{% block page_title %}
+  {% trans "Tasks" %}
+{% endblock %}
+
+{% block inner_content %}
+  <div class="dashboard">
+    <h1 class="heading-medium">{%block tasks_title %}{% trans "My tasks" %}{% endblock %}</h1>
+
+    <section class="table-show-hide">
+      <div class="table-title">
+        <h2 class="heading-medium">
+          <span class="bignum">{{tasks.update|length}}</span> {% trans "Update datasets" %}
+        </h2>
+        <div>
+          <a class="font-xsmall toggle" style="display:none">{% trans "Show all" %}</a>
+        </div>
+      </div>
+      <table>
+        <tbody>
+          {% for task in tasks.update %}
+            <tr>
+              <td>
+                {{ task.description }}
+              </td>
+              <td><div class="overdue">{{ task.label_text }}</div></td>
+              <td class="actions">
+                <a class="update" href="{% url 'edit_dataset_files' task.related_object_id %}">{% trans "Update" %}</a>
+                {% if can_skip %}
+                  <a href="{% url 'skip_task' task.id %}">{% trans "Skip" %}</a>
+                {% endif %}
+              </td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </section>
+
+    <section class="table-show-hide">
+      <div class="table-title">
+        <h2 class="heading-medium">
+          <span class="bignum">{{tasks.fix|length}}</span> {% trans "Fix datasets" %}
+        </h2>
+        <div>
+          <a class="font-xsmall toggle" style="display:none">{% trans "Show all" %}</a>
+        </div>
+      </div>
+      <table>
+        <tbody>
+          {% for task in tasks.fix %}
+            <tr>
+              <td>
+                {{ task.description }}
+              </td>
+              <td><div class="overdue">{{ task.label_text }}</div></td>
+              <td>
+                <a class="update" href="{% url 'edit_dataset_files' task.related_object_id %}">{% trans "Update" %}</a>
+                {% if can_skip %}
+                  <a href="{% url 'skip_task' task.id %}">{% trans "Skip" %}</a>
+                {% endif %}
+              </td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </section>
+
+    <div id="dashboard-stats" class="js-hidden">
+      <div id="orgs" style="display: none">{{ orgs }}</div>
+      <div id="api-endpoint" style="display: none">{{ api_endpoint }}</div>
+      <h2 class="heading-medium">{% trans "Most popular" %}</h2>
+      <table>
+        <thead>
+          <tr>
+            <th scope="col">{% trans "Name" %}</th>
+            <th scope="col">{% trans "Downloads" %}</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr id="row-template" style="display: none">
+            <td class="stats-title"></td>
+            <td>
+              <span class="stats-downloads"></span>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+  </div>
+{% endblock %}

--- a/src/tasks/templates/tasks/my.html
+++ b/src/tasks/templates/tasks/my.html
@@ -1,0 +1,7 @@
+{% extends "tasks/base.html" %}
+{% load i18n %}
+
+{%block tasks_title %}
+    {% trans "My tasks" %}
+    <a href="{% url 'organisation_tasks' %}">{{ organisation.title }}{% trans " tasks" %}</a>
+{% endblock %}

--- a/src/tasks/templates/tasks/organisation.html
+++ b/src/tasks/templates/tasks/organisation.html
@@ -1,0 +1,7 @@
+{% extends "tasks/base.html" %}
+{% load i18n %}
+
+{%block tasks_title %}
+    <a href="{% url 'my_tasks' %}">{% trans "My tasks" %}</a>
+    {{ organisation.title }}{% trans " tasks" %}
+{% endblock %}

--- a/src/tasks/tests.py
+++ b/src/tasks/tests.py
@@ -5,7 +5,7 @@ from django.contrib.auth import get_user_model
 from django.urls import reverse
 
 from tasks.models import Task
-from tasks.logic import get_tasks_for_user, user_ignore_task
+from tasks.logic import get_tasks_for_user, user_ignore_task, get_tasks_for_organisation
 
 from datasets.logic import organisations_for_user
 from datasets.models import Organisation
@@ -71,3 +71,25 @@ class TasksTestCase(TestCase):
                                args=[tasks['update'][0].id]))
         assert resp.status_code == 302
         assert resp.url == "/", resp.url
+
+    def test_my_tasks(self):
+        response = self.client.post(reverse('signin'), {
+            "email": "test-signin@localhost",
+            "password": "password"
+        })
+        assert response.status_code == 302
+
+        tasks = get_tasks_for_organisation('test-org')
+        assert len(tasks['update']) == 1
+
+        tasks = get_tasks_for_user(self.test_user)
+        assert len(tasks['update']) == 1
+
+        resp = self.client.get(reverse('skip_task',
+                               args=[tasks['update'][0].id]))
+
+        tasks = get_tasks_for_user(self.test_user)
+        assert len(tasks['update']) == 0
+
+        tasks = get_tasks_for_organisation('test-org')
+        assert len(tasks['update']) == 1

--- a/src/tasks/urls.py
+++ b/src/tasks/urls.py
@@ -3,5 +3,7 @@ from django.conf.urls import url
 import tasks.views as v
 
 urlpatterns = [
+    url(r'organisation$', v.organisation_tasks, name='organisation_tasks'),
     url(r'skip/(?P<task_id>\d+)$', v.skip_task, name='skip_task'),
+    url(r'$', v.my_tasks, name='my_tasks'),
 ]

--- a/src/tasks/views.py
+++ b/src/tasks/views.py
@@ -1,9 +1,9 @@
 from django.http import HttpResponseRedirect
-from django.shortcuts import get_object_or_404
+from django.shortcuts import get_object_or_404, render
 from django.contrib.auth.decorators import login_required
 
 from tasks.models import Task
-from tasks.logic import user_ignore_task
+from tasks.logic import user_ignore_task, get_tasks_for_user, get_tasks_for_organisation
 
 
 @login_required()
@@ -12,3 +12,26 @@ def skip_task(request, task_id):
     user_ignore_task(request.user, task)
 
     return HttpResponseRedirect(request.META.get('HTTP_REFERER', '/'))
+
+@login_required()
+def my_tasks(request):
+    organisation = request.user.primary_organisation()
+
+    tasks = get_tasks_for_user(request.user)
+
+    return render(request, "tasks/my.html", {
+        'organisation': organisation,
+        'tasks': tasks,
+        'can_skip': True
+    })
+
+@login_required()
+def organisation_tasks(request):
+    organisation = request.user.primary_organisation()
+    tasks = get_tasks_for_organisation(organisation.name)
+
+    return render(request, "tasks/organisation.html", {
+        'organisation': organisation,
+        'tasks': tasks,
+        'can_skip': False
+    })


### PR DESCRIPTION
Adds views to the tasks app to handle My Tasks and Organisation tasks.
User tasks show all tasks except where they've skipped them.
Organisation tasks show all tasks until they are completed.

Views are at /tasks and /tasks/organisation and templates have been
copied from Dashboard but are wrong/placeholders only.

This is just speculative at the moment.