### PR TITLE
Make sure link checks do not verify certs and do timeout

### DIFF
--- a/src/tasks/management/commands/check_links.py
+++ b/src/tasks/management/commands/check_links.py
@@ -28,7 +28,7 @@ class Command(BaseCommand):
         time.sleep(0.5)
 
         try:
-            r = requests.head(url)
+            r = requests.head(url, timeout=(3.0, 3.0,), verify=False)
             ok = (r.status_code != 404)
         except Exception as e:
             print(str(e))


### PR DESCRIPTION
Link checks were not timing out quickly enough, and were breaking on
certs.  We can't necessarily verify all of the certificates so we'll
ignore it for now.