### PR TITLE
Use messages framework to tell user about deletions

### DIFF
--- a/src/datasets/views.py
+++ b/src/datasets/views.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 
+from django.contrib import messages
 from django.http import HttpResponseRedirect, HttpResponse, HttpResponseForbidden
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import render, redirect, get_object_or_404
@@ -85,8 +86,11 @@ def delete_dataset(request, dataset_name):
     unindex_dataset(dataset)
     dataset.delete()
 
+    msg = _('The dataset &#8220;%(title)s&#8221; has been deleted.') % {'title': dataset.title}
+    messages.add_message(request, messages.INFO, msg)
+
     return HttpResponseRedirect(
-        reverse('manage_data') + "?result=deleted"
+        reverse('manage_data')
     )
 
 
@@ -451,10 +455,17 @@ def _edit_publish_dataset(request, dataset, state):
 
             result = 'edited' if new_state == 'editing' else 'created'
 
+            if result == 'edited':
+                msg = _('Your dataset has been edited')
+                messages.add_message(request, messages.INFO, msg, extra_tags=dataset.name)
+            elif result == 'created':
+                msg = _('Your dataset has been published')
+                messages.add_message(request, messages.INFO, msg, extra_tags=dataset.name)
+
             request.session['flow-state'] = None
 
             return HttpResponseRedirect(
-                reverse('manage_data') + "?result=" + result
+                reverse('manage_data')
             )
     else:
         form = f.PublishForm()

--- a/src/publish_data/templates/manage.html
+++ b/src/publish_data/templates/manage.html
@@ -9,21 +9,14 @@
 {% block inner_content %}
   <main id="content" role="main" tabindex="-1">
 
-    {% if result == "created" %}
+    {% if messages %}
       <div class="govuk-box-highlight">
-        <h1 class="bold-large">{% trans "Your dataset has been published" %}</h1>
-        <h2><a href="{{ find_url }}/dataset/{{ datasets.first.name }}">{% trans "View it" %}</a></h2>
-      </div>
-    {% endif %}
-    {% if result == "deleted" %}
-      <div class="govuk-box-highlight">
-        <h1 class="bold-large">{% trans "Your dataset has been deleted" %}</h1>
-      </div>
-    {% endif %}
-    {% if result == "edited" %}
-      <div class="govuk-box-highlight">
-        <h1 class="bold-large">{% trans "Your dataset has been edited" %}</h1>
-        <a href="{{ find_url }}/dataset/{{ datasets.first.name }}">{% trans "View it" %}</a>
+        {% for message in messages %}
+          <h1 class="bold-large"> {{ message|safe }}</h1>
+          {% if message.extra_tags %}
+            <h2><a href="{{ find_url }}/dataset/{{ message.extra_tags }}">{% trans "View it" %}</a></h2>
+          {% endif %}
+        {% endfor %}
       </div>
     {% endif %}
 


### PR DESCRIPTION
Rather than passing ?result=deleted to manage_data, we instead use the
messages framework to set the text in the view.  See delete_dataset if
we need to pass arguments to the i18n.

We use extra_tags with the dataset name if we want a link to view it.