### PR TITLE
Add password reset flow.

### DIFF
--- a/src/userauth/templates/userauth/password_reset.html
+++ b/src/userauth/templates/userauth/password_reset.html
@@ -1,0 +1,54 @@
+{% extends 'main.html' %}
+{% load static %}
+{% load i18n %}
+
+{% block page_title %}
+  {% trans 'Your account' %}
+{% endblock %}
+
+{% block inner_content %}
+
+  <h1 class="heading-large">{% trans 'Password reset' %}</h1>
+
+  <p>Forgotten your password?</p>
+
+  <p>Enter your email address below, and we'll email instructions for setting a new one.</p>
+
+
+  <form
+      action="{% url 'password_reset' %}"
+      method="POST">
+    {% csrf_token %}
+
+    <fieldset>
+      <legend class="visuallyhidden">
+        {% trans "Provide an email address" %}
+      </legend>
+
+      <div
+          class="form-group {% if form.email.errors %}error{% endif %}"
+          id="email_form_group">
+        <label
+            class="form-label-bold"
+            for="id_email">
+          {% trans "Email" %}
+        </label>
+        {% for error in form.email.errors %}
+          <span class="error-message">{{ error }}</span>
+        {% endfor %}
+        <input
+            class="form-control form-control-2-3"
+            id="id_email"
+            name="{{ form.email.html_name }}"
+            type="text"
+            value="{{ form.email.value|default:"" }}"/>
+      </div>
+    </fieldset>
+
+    <p>
+      <input type="submit" class="button" value="{% trans 'Submit' %}"/>
+    </p>
+
+  </form>
+
+{% endblock %}

--- a/src/userauth/templates/userauth/password_reset.html
+++ b/src/userauth/templates/userauth/password_reset.html
@@ -3,7 +3,7 @@
 {% load i18n %}
 
 {% block page_title %}
-  {% trans 'Your account' %}
+  {% trans 'Password reset' %}
 {% endblock %}
 
 {% block inner_content %}

--- a/src/userauth/templates/userauth/password_reset.html
+++ b/src/userauth/templates/userauth/password_reset.html
@@ -10,9 +10,9 @@
 
   <h1 class="heading-large">{% trans 'Password reset' %}</h1>
 
-  <p>Forgotten your password?</p>
+  <p>{% trans 'Forgotten your password?' %}</p>
 
-  <p>Enter your email address below, and we'll email instructions for setting a new one.</p>
+  <p>{% trans "Enter your email address below, and we'll email instructions for setting a new one." %}</p>
 
 
   <form

--- a/src/userauth/templates/userauth/password_reset_complete.html
+++ b/src/userauth/templates/userauth/password_reset_complete.html
@@ -3,7 +3,7 @@
 {% load i18n %}
 
 {% block page_title %}
-  {% trans 'Your account' %}
+  {% trans 'Password reset' %}
 {% endblock %}
 
 {% block inner_content %}

--- a/src/userauth/templates/userauth/password_reset_complete.html
+++ b/src/userauth/templates/userauth/password_reset_complete.html
@@ -1,0 +1,15 @@
+{% extends 'main.html' %}
+{% load static %}
+{% load i18n %}
+
+{% block page_title %}
+  {% trans 'Your account' %}
+{% endblock %}
+
+{% block inner_content %}
+
+  <h1 class="heading-large">{% trans 'Password reset complete' %}</h1>
+
+  <p>{%trans "Your password has been reset, you may now" %} <a href="{% url 'signin' %}">sign in</a></p>
+
+{% endblock %}

--- a/src/userauth/templates/userauth/password_reset_confirm.html
+++ b/src/userauth/templates/userauth/password_reset_confirm.html
@@ -3,7 +3,7 @@
 {% load i18n %}
 
 {% block page_title %}
-  {% trans 'Your account' %}
+  {% trans 'Password reset' %}
 {% endblock %}
 
 {% block inner_content %}

--- a/src/userauth/templates/userauth/password_reset_confirm.html
+++ b/src/userauth/templates/userauth/password_reset_confirm.html
@@ -10,7 +10,7 @@
 
   <h1 class="heading-large">{% trans 'Enter new password' %}</h1>
 
-  <p>Please enter your new password twice so we can verify you typed it in correctly.</p>
+  <p>{% trans "Please enter your new password twice so we can verify you typed it in correctly." %}</p>
 
   <form action="" method="post">
     {% csrf_token %}

--- a/src/userauth/templates/userauth/password_reset_confirm.html
+++ b/src/userauth/templates/userauth/password_reset_confirm.html
@@ -1,0 +1,74 @@
+{% extends 'main.html' %}
+{% load static %}
+{% load i18n %}
+
+{% block page_title %}
+  {% trans 'Your account' %}
+{% endblock %}
+
+{% block inner_content %}
+
+  <h1 class="heading-large">{% trans 'Enter new password' %}</h1>
+
+  <p>Please enter your new password twice so we can verify you typed it in correctly.</p>
+
+  <form action="" method="post">
+    {% csrf_token %}
+
+    <fieldset>
+      <legend class="visuallyhidden">
+        {% trans "Provide an email address" %}
+      </legend>
+
+      <div
+          class="form-group {% if form.new_password1.errors %}error{% endif %}"
+          id="new_password1_form_group">
+        <label
+            class="form-label-bold"
+            for="id_new_password1">
+          {% trans "New password" %}
+        </label>
+        {% for error in form.new_password1.errors %}
+          <span class="error-message">{{ error }}</span>
+        {% endfor %}
+        <input
+            class="form-control form-control-2-3"
+            id="id_new_password1"
+            name="{{ form.new_password1.html_name }}"
+            type="password"
+            value="{{ form.new_password1.value|default:"" }}"/>
+      </div>
+
+      <div
+          class="form-group {% if form.new_password2.errors %}error{% endif %}"
+          id="new_password2_form_group">
+        <label
+            class="form-label-bold"
+            for="id_new_password2">
+          {% trans "Confirm password" %}
+        </label>
+        {% for error in form.new_password2.errors %}
+          <span class="error-message">{{ error }}</span>
+        {% endfor %}
+        <input
+            class="form-control form-control-2-3"
+            id="id_email"
+            name="{{ form.new_password2.html_name }}"
+            type="password"
+            value="{{ form.new_password2.value|default:"" }}"/>
+      </div>
+
+    </fieldset>
+
+    <p>
+      <input type="submit" class="button" value="{% trans 'Change password' %}"/>
+    </p>
+
+  </form>
+
+
+
+
+
+
+{% endblock %}

--- a/src/userauth/templates/userauth/password_reset_done.html
+++ b/src/userauth/templates/userauth/password_reset_done.html
@@ -3,7 +3,7 @@
 {% load i18n %}
 
 {% block page_title %}
-  {% trans 'Your account' %}
+  {% trans 'Password reset' %}
 {% endblock %}
 
 {% block inner_content %}

--- a/src/userauth/templates/userauth/password_reset_done.html
+++ b/src/userauth/templates/userauth/password_reset_done.html
@@ -1,0 +1,17 @@
+{% extends 'main.html' %}
+{% load static %}
+{% load i18n %}
+
+{% block page_title %}
+  {% trans 'Your account' %}
+{% endblock %}
+
+{% block inner_content %}
+
+  <h1 class="heading-large">{% trans 'Password reset sent' %}</h1>
+
+  <p>{%trans "We've emailed you instructions for setting your password, if an account exists with the email you entered. You should receive them shortly." %}</p>
+
+  <p>{% trans "If you don't receive an email, please make sure you've entered the address you registered with, and check your spam folder." %}</p>
+
+{% endblock %}

--- a/src/userauth/urls.py
+++ b/src/userauth/urls.py
@@ -1,13 +1,37 @@
-from django.conf.urls import url
+from django.conf.urls import url, include
 from django.contrib.auth.decorators import login_required
 
 from .views import login_view, logout_view, user_view
+from django.contrib.auth.views import (password_reset,
+                                       password_reset_done,
+                                       password_reset_confirm,
+                                       password_reset_complete)
 import userauth.views as v
 
 urlpatterns = [
     url(r'signin$', login_view, name='signin'),
     url(r'signout$', logout_view, name='signout'),
-    url(r'^user/(?P<username>[^/]+)/$',
+    url(r'user/(?P<username>[^/]+)/$',
         login_required(v.user_view),
-        name='user')
+        name='user'),
+
+    url(r'^password_reset/$', password_reset, {
+            'template_name': 'userauth/password_reset.html'
+        },
+        name='password_reset'),
+
+    url(r'^password_reset/done/$', password_reset_done, {
+            'template_name': 'userauth/password_reset_done.html'
+        },
+        name='password_reset_done'),
+
+    url(r'^reset/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/$',
+        password_reset_confirm, {
+            'template_name': 'userauth/password_reset_confirm.html'
+        },
+        name='password_reset_confirm'),
+    url(r'^reset/done/$', password_reset_complete, {
+            'template_name': 'userauth/password_reset_complete.html'
+        },
+        name='password_reset_complete'),
 ]


### PR DESCRIPTION
Uses the django password reset flow, with some *temporary* HTML to make
it work.  Currently relies on SMTP delivery which we don't have setup so
another PR will follow with SMTP setup and templates for the mail
delivery.