### PR TITLE
Add a link to password reset on signin page.

### DIFF
--- a/src/userauth/templates/userauth/signin.html
+++ b/src/userauth/templates/userauth/signin.html
@@ -53,6 +53,11 @@
           name="password"
           type="password">
     </div>
-    <input class="button" type="submit" value="{% trans "Sign in" %}"/>
+    <p>
+      <input class="button" type="submit" value="{% trans "Sign in" %}"/>
+    </p>
+    <p>
+      <a class="secondary-button" href="{% url 'password_reset' %}">Forgot your password?</a>
+    </p>
   </form>
 {% endblock %}


### PR DESCRIPTION
Uses similar HTML to the skip link in the datasets flow to make sure the
secondary-button is below the primary.