### PR TITLE
Allow dataset_list to return subsets of the objects

### DIFF
--- a/src/datasets/logic.py
+++ b/src/datasets/logic.py
@@ -19,7 +19,7 @@ def publish(dataset, user):
         unindex_dataset(dataset)
 
 
-def dataset_list(user, page=1, filter_query=None, sort=None, only_user = False):
+def dataset_list(user, page=1, filter_query=None, sort=None, only_user=False, fields=None):
     """
     For the given user returns a tuple containing total number of datasets
     both draft and published, and the 20 most recent.
@@ -43,6 +43,9 @@ def dataset_list(user, page=1, filter_query=None, sort=None, only_user = False):
         q = q.order_by(sort)
 
     start = (per_page * page) - per_page
+    if fields:
+        q = q.values(*fields)
+
     datasets = q.all()[start:start+per_page]
 
     total = q.count()

--- a/src/datasets/tests/test_logic.py
+++ b/src/datasets/tests/test_logic.py
@@ -1,0 +1,65 @@
+from django.test import TestCase
+
+from .factories import (GoodUserFactory,
+                        NaughtyUserFactory,
+                        OrganisationFactory,
+                        DatasetFactory,
+                        DatafileFactory)
+
+from datasets.logic import dataset_list
+
+class LogicCase(TestCase):
+
+    def setUp(self):
+        self.test_user = GoodUserFactory.create()
+        self.organisation = OrganisationFactory.create()
+        self.organisation.users.add(self.test_user)
+        self.dataset1 = DatasetFactory.create(name='one',
+            title='One',
+            description='dataset one',
+            summary='dataset one summary',
+            owner=self.test_user,
+            organisation_id=self.organisation.id)
+        self.dataset2 = DatasetFactory.create(name='two',
+            title='Two',
+            description='dataset two',
+            summary='dataset two summary',
+            owner=self.test_user,
+            organisation_id=self.organisation.id)
+        self.dataset3 = DatasetFactory.create(name='three',
+            title='Three',
+            description='dataset three',
+            summary='dataset three summary',
+            organisation_id=self.organisation.id)
+
+    def test_list(self):
+        total, _, l = dataset_list(self.test_user)
+        assert total == 3, total
+
+    def test_list_filter(self):
+        total, _, l = dataset_list(self.test_user, filter_query='two')
+        assert total == 1, total
+
+    def test_list_useronly(self):
+        total, _, l = dataset_list(self.test_user, only_user=True)
+        assert total == 2, total
+
+    def test_list_limited(self):
+        # dataset_list(user, page=1, filter_query=None, sort=None, only_user = False):
+        total, _, l = dataset_list(self.test_user, fields=['name', 'title'])
+        d1, _, _ = l
+        assert len(d1.keys()) == 2
+        assert 'name' in d1
+        assert 'title' in d1
+
+    def test_list_limited_filter(self):
+        total, _, l = dataset_list(
+            self.test_user,
+            filter_query='one',
+            fields=['name', 'title']
+        )
+
+        assert len(l) == 1
+        assert len(l[0].keys()) == 2
+        assert 'name' in l[0]
+        assert 'title' in l[0]


### PR DESCRIPTION
Fetching model objects is expensive, and in cases where we want to
filter and return a couple of fields to the browser it's inefficient.

This PR, apart from adding some tests for dataset_list also allow you to
specify the fields you want returned from the lookup.  If you pass a
list of field names in ```fields``` you will receive back a QuerySet
that contains a list of dicts, containing only those fields.  You can
then cast this to list and return to the client.

```python
total, _, l = dataset_list(self.test_user, fields=['name', 'title'])
items = list(l)
print(items)
[{'name': 'one', 'title': 'One'}]
```

Fixes #443