### PR TITLE
Replace pagination and sort links

### DIFF
--- a/src/api/views.py
+++ b/src/api/views.py
@@ -30,7 +30,11 @@ def dataset_lookup(request):
         request.user, filter_query=q, sort=sort,
         only_user=only_user, fields=['title', 'name', 'published']
     )
-    return JsonResponse(list(datasets), safe=False)
+    return JsonResponse(
+        { 'total': total,
+          'datasets': list(datasets)
+        }, safe=False
+    )
 
 
 class StatusEndpoint(ProtectedResourceView):

--- a/src/assets/javascripts/app.js
+++ b/src/assets/javascripts/app.js
@@ -10,10 +10,38 @@
   };
 
   // escape strings injected into the DOM
-  function escapeHtml(str) {
+  function safeText(str) {
     var div = document.createElement('div');
     div.appendChild(document.createTextNode(str));
     return div.innerHTML;
+  }
+
+  // query string management
+  function splitUrl(url) {
+    var match;
+    var pl     = /\+/g;  // Regex for replacing addition symbol with a space
+    var search = /([^&=]+)=?([^&]*)/g;
+    var decode = function (s) { return decodeURIComponent(s.replace(pl, " ")); };
+    var query  = window.location.search.substring(1);
+    var urlParams = {
+      base: window.location.origin + window.location.pathname,
+      params: {}
+    };
+
+    while (match = search.exec(query)) {
+     urlParams.params[decode(match[1])] = decode(match[2]);
+    }
+    return urlParams;
+  }
+
+  function buildUrl(urlObj) {
+    var queryString = '';
+    for (var param in urlObj.params) {
+      queryString +=
+        (queryString == '' ? '?' : '&') +
+        param + '=' + urlObj.params[param];
+    }
+    return urlObj.base + queryString;
   }
 
   // Components
@@ -194,30 +222,78 @@
 
   var searchDatasetsAsYouType = {
 
+    buildResultsTable: function(results) {
+      $('#dataset-list').html('');
+      results.forEach(function(item) {
+        var safeName = encodeURIComponent(item.name);
+        var safeTitle = safeText(item.title);
+        var findUrl = $('#find-url').text();
+        var markup = '<tr><td><a href="'+findUrl+
+          safeName + '">' + safeTitle +
+          '</a></td><td>' +
+          (item.published ? 'Published' : 'Draft') +
+          '</td><td class="actions">' +
+          '<a href="/dataset/' +
+          safeName +
+          '/addfile/">Add&nbsp;Data</a>' +
+          '<a href="/dataset/edit/' +
+          safeName +
+          '">Edit</a></td></tr>';
+        $('#dataset-list').append(markup);
+      });
+    },
+
+    buildPagination: function($paginationSection, numResults, searchQuery) {
+      $paginationSection.html('');
+      if (numResults>20) {
+        for (var i=1; i <= Math.ceil(numResults/20); i++) {
+          $paginationSection.append(
+            '<span><a href="?page='+i+'&amp;q='+searchQuery+'">' +
+              i + '</a> </span>'
+                );
+        }
+      }
+    },
+
+    changeSortLinks: function(searchQuery) {
+      $('.sortable-heading').each(function() {
+        var link =$(this).find('a');
+        var hrefObj = splitUrl(link.attr('href'));
+        hrefObj.params.q = searchQuery;
+        link.attr('href', buildUrl(hrefObj));
+      });
+    },
+
     init: function() {
+      var self = this;
       $('#filter-dataset-form #q').on('keyup', function(event) {
+        var safeSearchQuery = encodeURIComponent(this.value);
         $.get('/api/datasets?q=' + this.value)
-        .success(function(searchResults) {
-          if (searchResults.length) {
-            $('#dataset-list').html('');
-            searchResults.forEach(function(item) {
-              var safeName = escapeHtml(item.name);
-              var safeTitle = escapeHtml(item.title);
-              var markup = '<tr><td><a href="http://localhost:8001/dataset/'+
-                    safeName + '">' + safeTitle +
-                    '</a></td><td>' +
-                    (item.published ? 'Published' : 'Draft') +
-                    '</td><td class="actions">' +
-                    '<a href="/dataset/' +
-                    safeName +
-                    '/addfile/">Add&nbsp;Data</a>' +
-                    '<a href="/dataset/edit/' +
-                    safeName +
-                    '">Edit</a></td></tr>';
-              $('#dataset-list').append(markup);
-            });
-          }
-        });
+          .success(function(response) {
+            var numResults = response.total;
+            var $paginationSection = $('.pagination');
+
+            if (numResults == 0) {
+              $('.manage-data').hide();
+              $('.noresults').show();
+            } else {
+              var searchResults = response.datasets;
+
+              $('.manage-data').show();
+              $('.noresults').hide();
+
+              // rebuild the table with results
+              self.buildResultsTable(searchResults);
+              self.changeSortLinks(safeSearchQuery);
+            }
+
+            self.buildPagination(
+              $paginationSection,
+              numResults,
+              safeSearchQuery
+            );
+
+          });
       });
     }
   };

--- a/src/publish_data/templates/manage/base.html
+++ b/src/publish_data/templates/manage/base.html
@@ -7,6 +7,8 @@
 {% endblock %}
 
 {% block inner_content %}
+  <div style="display:none" id="find-url">{{ find_url }}</div>
+
   <main id="content" role="main" tabindex="-1">
 
     {% if messages %}
@@ -53,75 +55,79 @@
                   id="q"
                   name="q"
                   type="text"
+                  autocomplete="off"
                   value="{{ q }}"/>
             </label>
           </div>
-          {% if q %}
-            <a class="font-xsmall" href="{% url 'manage_my_data' %}">{% trans "Reset search" %}</a>
-          {% endif %}
         </fieldset>
       </form>
 
-      {% if datasets %}
-        <table class="manage-data">
-          <thead>
+      <table
+          class="manage-data"
+          {% if not datasets %}style="display:none"{% endif %}>
+        <thead>
+          <tr>
+            <th class="sortable-heading">
+              <a
+                  href="{{ qs_name_next }}"
+                  class="{% if sort == 'name' %}sort-ascending{% elif sort == '-name' %}sort-descending{% endif %}">
+                {% trans 'Dataset name' %}
+              </a>
+            </th>
+            <th class="sortable-heading">
+              <a
+                  href="{{ qs_published_next }}"
+                  class="{% if sort == 'published' %}sort-ascending{% elif sort == '-published' %}sort-descending{% endif %}">
+                {% trans 'Status' %}
+              </a>
+            </th>
+            <th><span class="visuallyhidden">{% trans 'Actions' %}</span></th>
+          </tr>
+        </thead>
+        <tbody id="dataset-list">
+          {% for dataset in datasets %}
             <tr>
-              <th class="sortable-heading">
-                <a
-                    href="{{ qs_name_next }}"
-                    class="{% if sort == 'name' %}sort-ascending{% elif sort == '-name' %}sort-descending{% endif %}">
-                  {% trans 'Dataset name' %}
-                </a>
-              </th>
-              <th class="sortable-heading">
-                <a
-                    href="{{ qs_published_next }}"
-                    class="{% if sort == 'published' %}sort-ascending{% elif sort == '-published' %}sort-descending{% endif %}">
-                  {% trans 'Status' %}
-                </a>
-              </th>
-              <th><span class="visuallyhidden">{% trans 'Actions' %}</span></th>
+              <td>
+                {% if find_url and dataset.published %}
+                  <a href="{{ find_url }}/dataset/{{ dataset.name }}">{{ dataset.title }}</a>
+                {% else %}
+                  {{ dataset.title }}
+                {% endif %}
+              </td>
+              <td>
+                {% if dataset.published %}
+                  {% trans "Published" %}
+                {% else %}
+                  {% trans "Draft" %}
+                {% endif %}
+              </td>
+              <td class="actions">
+                {% if dataset.name %}
+                  <a href="{% url 'edit_dataset_addfile' dataset.name %}">{% trans "Add&nbsp;Data" %}</a>
+                  <a href="{% url 'edit_full_dataset' dataset.name %}">{% trans "Edit" %}</a><br/>
+                {% endif %}
+              </td>
             </tr>
-          </thead>
-          <tbody id="dataset-list">
-            {% for dataset in datasets %}
-              <tr>
-                <td>
-                  {% if find_url and dataset.published %}
-                    <a href="{{ find_url }}/dataset/{{ dataset.name }}">{{ dataset.title }}</a>
-                  {% else %}
-                    {{ dataset.title }}
-                  {% endif %}
-                </td>
-                <td>
-                  {% if dataset.published %}
-                    {% trans "Published" %}
-                  {% else %}
-                    {% trans "Draft" %}
-                  {% endif %}
-                </td>
-                <td class="actions">
-                  {% if dataset.name %}
-                    <a href="{% url 'edit_dataset_addfile' dataset.name %}">{% trans "Add&nbsp;Data" %}</a>
-                    <a href="{% url 'edit_full_dataset' dataset.name %}">{% trans "Edit" %}</a><br/>
-                  {% endif %}
-                </td>
-              </tr>
-            {% endfor %}
-          </tbody>
-        </table>
-      {% else %}
-        <p>{% trans "No results found" %}</p>
-      {% endif %}
+          {% endfor %}
+        </tbody>
+      </table>
+      <p
+          class="noresults"
+          style="display:{% if not datasets %}block{% else %}none{% endif %}">
+        {% trans "No results found" %}
+      </p>
+
 
       <div class="pagination">
-        {% for page in page_range %}
-          {% if page == current_page %}
-            <span>{{ current_page }}</span>
-          {% else %}
-            <span><a href="?page={{ page }}{% if q %}&q={{ q }}{% endif %}{% if sort %}&sort={{ sort }}{% endif %}">{{ page }}</a></span>
-          {% endif %}
-        {% endfor %}
+        {% if page_range|length > 1 %}
+          {% for page in page_range %}
+            {% if page == current_page %}
+              <span>{{ current_page }}</span>
+            {% else %}
+              <span><a href="?page={{ page }}{% if q %}&q={{ q }}{% endif %}{% if sort %}&sort={{ sort }}{% endif %}">{{ page }}</a></span>
+            {% endif %}
+          {% endfor %}
+        {% endif %}
       </div>
     </div>
   </main>

--- a/src/publish_data/views.py
+++ b/src/publish_data/views.py
@@ -69,7 +69,7 @@ def _manage_context(request, only_user, view_name):
         "datasets": datasets,
         "organisation": organisation,
         "total": total,
-        "page_range": range(1, page_count),
+        "page_range": range(1, page_count + 1),
         "current_page": page,
         "q": q or "",
         "find_url": settings.FIND_URL or ckan_host,


### PR DESCRIPTION
search-as-you type now generates corrects links for sorting columns and pagination.
It now also handles empty results correctly