### PR TITLE
Simple robots.txt

### DIFF
--- a/src/publish_data/urls.py
+++ b/src/publish_data/urls.py
@@ -1,4 +1,5 @@
 from django.views.generic import TemplateView
+from django.http import HttpResponse
 from django.conf.urls import url, include
 from . import views
 
@@ -10,6 +11,7 @@ urlpatterns = [
 
     url(r'^$', views.home, name='home'),
     url(r'^cookies$', TemplateView.as_view(template_name='cookies.html'), name='cookies'),
+    url(r'^robots.txt', lambda x: HttpResponse("User-Agent: *\nDisallow: /\n", content_type="text/plain"), name="robots_file"),
     url(r'^manage/$', views.manage_my_data, name='manage_my_data'),
     url(r'^manage/organisation/$', views.manage_org_data, name='manage_org_data'),
     url(r'^accounts/', include('userauth.urls')),


### PR DESCRIPTION
This is not the right way to do this, as it creates a session. We should eventually serve it directly from nginx, along with all other static files. Not sure PaaS supports that.