### PR TITLE
Creates tasks for overdue datasets

### DIFF
--- a/src/tasks/fixtures/tasks.json
+++ b/src/tasks/fixtures/tasks.json
@@ -56,28 +56,6 @@
   },
   {
     "model": "tasks.task",
-    "pk": 18,
-    "fields": {
-      "owning_organisation": "cabinet-office",
-      "required_permission_name" : "",
-      "quantity": 0,
-      "description": "Delete Maria Izquierdo’s account",
-      "category": "update"
-    }
-  },
-  {
-    "model": "tasks.task",
-    "pk": 19,
-    "fields": {
-      "owning_organisation": "cabinet-office",
-      "required_permission_name" : "",
-      "quantity": 0,
-      "description": "Give ‘editor’ permissions to Max Froumentin",
-      "category": "update"
-    }
-  },
-  {
-    "model": "tasks.task",
     "pk": 20,
     "fields": {
       "owning_organisation": "cabinet-office",

--- a/src/tasks/management/commands/check_links.py
+++ b/src/tasks/management/commands/check_links.py
@@ -47,7 +47,7 @@ class Command(BaseCommand):
             print('+ Dataset {} has {} links'.format(dataset.name, dataset.files.count()))
 
             # If this dataset has an existing task, then skip it.
-            task_count = Task.objects.filter(related_object_id=dataset.name).count()
+            task_count = Task.objects.filter(related_object_id=dataset.name, category='fix').count()
             if task_count > 0:
                 print('- Skipping {}, task exists'.format(dataset.name))
                 continue

--- a/src/tasks/management/commands/check_overdue.py
+++ b/src/tasks/management/commands/check_overdue.py
@@ -1,0 +1,69 @@
+import datetime
+import os
+import sys
+import logging
+import requests
+import time
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+
+from datasets.models import Organisation
+from datasets.logic import (most_recent_datafile,
+                            number_days_for_frequency,
+                            is_dataset_overdue)
+
+from tasks.models import Task
+
+log = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = 'Checks whether datasets are overdue records the result'
+
+    def add_arguments(self, parser):
+        parser.add_argument('--organisation', '-o', dest='organisation')
+
+
+    def process_organisation(self, organisation):
+        print('+ Checking overdue datasets for {}'.format(organisation))
+        print('    {} datasets'.format(organisation.datasets.count()))
+        for dataset in organisation.datasets.all():
+            if not dataset.frequency or dataset.frequency in ['never', 'daily']:
+                continue
+
+            print(dataset.name + " " + dataset.frequency)
+            df = most_recent_datafile(dataset)
+            if not df:
+                continue
+
+            # If this dataset has an existing task, then skip it.
+            task_count = Task.objects.filter(related_object_id=dataset.name,category='update').count()
+            if task_count > 0:
+                print('- Skipping {}, task exists'.format(dataset.name))
+                continue
+
+            if is_dataset_overdue(dataset):
+                print('+ Dataset {} is overdue'.format(dataset.name))
+                msg = 'Add missing data to {}'.format(dataset.title)
+                Task.objects.create(
+                    owning_organisation=organisation.name,
+                    related_object_id=dataset.name,
+                    description=msg,
+                    category='update'
+                )
+
+    def handle(self, *args, **options):
+        org_name = options.get('organisation')
+
+        if not org_name:
+            log.error('Overdue checker currently only processes single organisations')
+            sys.exit(1)
+
+        try:
+            organisation = Organisation.objects.get(name=org_name)
+        except Organisation.DoesNotExist:
+            log.error('Organisation {} not found'.format(org_name))
+            sys.exit(1)
+
+        self.process_organisation(organisation)

--- a/src/tasks/models.py
+++ b/src/tasks/models.py
@@ -7,8 +7,7 @@ from django.db import models
 
 TASK_CATEGORIES = (
     ("update",   _("Update datasets"), ),
-    ("fix",      _("Fix datasets"), ),
-    ("missing",  _("Missing data"), ),
+    ("fix",      _("Fix datasets"), )
 )
 
 


### PR DESCRIPTION
For a given organisation, will iterate through their datasets and mark
those that are overdue as overdue.  This doesn't always work with legacy
data, but seems to pick up most.

This fixes #369