### PR TITLE
Disable audit when using test settings

### DIFF
--- a/src/datasets/views.py
+++ b/src/datasets/views.py
@@ -8,13 +8,13 @@ from django.urls import reverse
 from django.utils.translation import ugettext as _
 from django.conf import settings
 
-import papertrail
 
 import datasets.forms as f
 from datasets.auth import user_can_edit_dataset, user_can_edit_datafile
 from datasets.logic import organisations_for_user, publish
 from datasets.models import Dataset, Datafile
 from datasets.search import delete_dataset as unindex_dataset
+from runtime_config.audit import audit_log
 
 
 def _set_flow_state(request):
@@ -48,7 +48,7 @@ def new_dataset(request):
                 organisation=user_org
             )
 
-            papertrail.log(
+            audit_log(
                 'new-dataset',
                 '{} created a new dataset "{}"'.format(request.user.username,
                                                        obj.title),
@@ -96,7 +96,7 @@ def delete_dataset(request, dataset_name):
     if dataset.published and not request.user.is_staff:
         return HttpResponseForbidden()
 
-    papertrail.log(
+    audit_log(
         'delete-dataset',
         '{} deleted "{}"'.format(request.user.username, dataset.title),
         data={
@@ -495,7 +495,7 @@ def _edit_publish_dataset(request, dataset, state, deleting=False):
                     request.user.username, dataset.title
                 )
 
-            papertrail.log(
+            audit_log(
                 'edit-dataset' if new_state == 'editing' else 'publish-dataset',
                 msg,
                 data={

--- a/src/publish_data/settings/base.py
+++ b/src/publish_data/settings/base.py
@@ -177,6 +177,9 @@ STATICFILES_DIRS = [
     os.path.join(PROJECT_DIR, "assets"),
 ]
 
+# Should papertrail log all audit messages?
+AUDIT = True
+
 ANALYTICS_ID = os.environ.get('GA_CODE') or ''
 
 ES_HOSTS = os.environ.get('ES_HOSTS')

--- a/src/publish_data/settings/test.py
+++ b/src/publish_data/settings/test.py
@@ -3,6 +3,9 @@ from .base import *
 
 ES_INDEX = 'data_discovery_test'
 
+# Disable papertrail during tests
+AUDIT = False
+
 # Speed up logins during testing/dev
 PASSWORD_HASHERS = [
     'django.contrib.auth.hashers.MD5PasswordHasher',

--- a/src/runtime_config/audit.py
+++ b/src/runtime_config/audit.py
@@ -1,0 +1,8 @@
+from django.conf import settings
+
+import papertrail
+
+
+def audit_log(*args, **kwargs):
+    if settings.AUDIT == True:
+        papertrail.log(*args, **kwargs)

--- a/src/userauth/views.py
+++ b/src/userauth/views.py
@@ -5,7 +5,7 @@ from django.conf import settings
 
 from .forms import SigninForm
 
-import papertrail
+from runtime_config.audit import audit_log
 
 
 def login_view(request):
@@ -20,7 +20,7 @@ def login_view(request):
             if user is not None:
                 login(request, user)
 
-                papertrail.log(
+                audit_log(
                     'login',
                     '{} logged in'.format(user.username),
                     data={


### PR DESCRIPTION
Papertrail uses Postgres specific functionality, and so when running
tests with sqlite we should avoid calling papertrail.log.