### PR TITLE
Increase max size for description (aka notes aka additional info)

### DIFF
--- a/src/datasets/forms.py
+++ b/src/datasets/forms.py
@@ -11,7 +11,7 @@ class DatasetForm(forms.Form):
     summary = forms.CharField(label=_('Summary'), max_length=200, required=True)
     description = forms.CharField(
         label=_('Additional Information'),
-        max_length=1024,
+        max_length=8096,
         widget=forms.Textarea,
         required=False
     )
@@ -30,7 +30,7 @@ class EditDatasetForm(forms.ModelForm):
     summary = forms.CharField(label=_('Summary'), max_length=200, required=True)
     description = forms.CharField(
         label=_('Additional Information'),
-        max_length=1024,
+        max_length=8096,
         widget=forms.Textarea,
         required=False
     )


### PR DESCRIPTION
It was set to 1024, which is reasonable, but is a lot smaller than some
of our current descriptions.  Have bumped it up to 8k ish for now (which
is almost certainly too large, should use documentation links at this
point).